### PR TITLE
user stories: Remove TUF specific fluff

### DIFF
--- a/docs/USER-STORIES.md
+++ b/docs/USER-STORIES.md
@@ -27,74 +27,59 @@ User wants to see what release of project ABC are available
 
 Admin wants to create a new repository.
 
-### “Modify top level metadata”
-
-Admin wants full control over the metadata: e.g. change consistent_snapshot, add custom metadata. This likely requires ability to upload complete metadata files
-
-This change could require additional signatures to be valid.
-
-### “Modify top level keys”
-
-Admin wants to add, remove or replace keys: either offline or online toplevel keys.
-
-This change could require additional signatures to be valid.
-
 ### “Modify configuration”
-Admin wants to modify configuration of the system that is not by TUF spec part of the metadata
-(e.g. when to run timestamp process).
 
-###  “Block a delegation (prevent metadata from being served)”
+Admin wants to modify configuration of the system
 
-Admin wants to prevent a project from spreading malware: either stop delegation completely or something else (? maybe modify the delegation to exclude some targets?)
+###  “Block trust delegation”
 
-This change could require additional signatures to be valid.
+Admin wants to prevent a project from spreading malware: Stop serving some (or all) published artifacts and possibly prevent the project from releasing any artifacts.
 
 ## Project maintainer
 
-### “Add new Project (delegation)”
+### “Create Project (delegation)”
 
-A new maintainer wants to create a new project in the repository, reserving the project name
+A new maintainer wants to create a new project in the repository, reserving the project name: This delegates trust from the repository to the maintainer for this specific project.
 
-This is a special subcase of “Modify keys for delegated metadata”
+This is a special case in that it is a "write" action but the repository does not necessarily have any existing relationship with the maintainer: in essence new project creation is available to anyone on the internet. 
 
-### “Modify keys/threshold for a project”
+**For TUF this is a special case as well: every other action is "authorized" by the fact that the change is signed by correct keys... In this case we want to add new keys and create a new delegation without the proposed change being signed by any keys**
 
-Maintainer wants to add a new maintainer to the project, remove an existing maintainer's key or change the key for an existing maintainer.
+### “Add/remove maintainers to a project”
 
-This change could require additional signatures to be valid.
+Maintainer wants to add a new maintainer to the project, remove an existing maintainer or change the authentication mechanism for an existing maintainer.
 
-**This is maybe the most interesting story: it requires modifying delegating metadata but also needs to be automated – PEP480 does not solve this problem**
+**For TUF This is maybe the most interesting story: it requires modifying delegating metadata but also needs to be automated – PEP480 does not solve this problem**
 
-### “Add new release (a target to delegated metadata)”
+### “Add new release to a project”
 
-Maintainer wants to upload a new release, and add target to delegated metadata
+Maintainer wants to upload a new release artifact
 
-This change could require additional signatures to be valid.
+### “Remove a release
 
-### “Remove a release (a target from delegated metadata)”
+Maintainer wants to remove or at least prevent downloads of an existing artifact
 
-Maintainer wants to remove or block the download of an existing release
-
-This change could require additional signatures to be valid.
-
-### “Sign a change made by another maintainer”
+### “Approve a change made by another maintainer”
 
 Maintainer wants to approve a change made by another maintainer
 
+**This use case assumes the repository supports "threshold of maintainers" for specific actions**
+
 ### “See current project state”
 
-Maintainer wants to see what targets are available, who the maintainers are, what are the key/threshold settings. This is a preliminary part of every other story.
+Maintainer wants to see details of a project: what artifacts are are available, who the maintainers are, etc.
 
-This could be done with a website – but it’s good to acknowledge that the website output would not be protected by TUF... Some project state might have to be available via means protected by TUF. 
+## Major open questions for TUF implementations of these use cases
 
+### How are maintainers able to add/remove maintainers?
 
-## Major open questions
+This is pretty critical: Adding/removing maintainers (keys) means modifying the **delegating** metadata. With the PEP-480 metadata structure that means metadata signed by repository admins, not the project maintainers.
 
-### How are maintainers able to modify keys for the project?
+This is not realistic: Repository admins cannot start signing targets changes for every project key modification. A multi-level project metadata structure would make it at least possible… still might not be reasonable for repo admins
 
-This is pretty critical: Repository admins can’t start signing targets changes for every project key modification. A multi-level project metadata structure would make it at least possible… still might not be reasonable for repo admins
+### Approving changes made by other maintainers
 
-### multisig
+This is a feature current repository implementations do not have, but it is something TUF would enable. The practical implementation might not be trivial though.
 
 How does a maintainer know there is a change from another maintainer  to sign? How do they refer to the change? How do they review the change for correctness? The developer tool can’t just trust the server on this: it must assume the repository is compromised. The new metadata should probably be available via normal metadata download: just not part of official snapshot yet – so that there is a single possible “next version” of metadata that can either be A) overwritten or B) multisigned
 


### PR DESCRIPTION
Keep the user stories generic, leave the TUF related comments to a
minimum. The idea is to describe what the repository can do, whether
it's implemented with TUF or not.

Signed-off-by: Jussi Kukkonen <jkukkonen@vmware.com>

---

Fixes #8