### PR TITLE
Git-repo: Implement deploy action

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -46,6 +46,8 @@ Current signing requirements are:
 
 1. Fork the [template](https://github.com/jku/playground-template). Enable
    _Settings->Actions->Allow GitHub Actions to create and approve pull requests_.
+1. To enable repository publishing, set _Settings->Pages->Source to `Github Actions`. Add `deploy` as
+   a deployment branch in _Settings->Environments_.
 1. Make sure Google Cloud allows this repository OIDC identity to sign with a KMS key
 
 ### Create TUF metadata (the initial signing event)

--- a/playground/actions/compile/action.yml
+++ b/playground/actions/compile/action.yml
@@ -7,7 +7,20 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: mkdir "$INPUT_PATH" && echo "test content..." >> "$INPUT_PATH/root.json"
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      with:
+        fetch-depth: 0
+
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
+      with:
+        python-version: 3.11
+
+    - run: pip install $GITHUB_ACTION_PATH/../../repo/
+      shell: bash
+
+    - run: |
+        playground-publish "$INPUT_PATH"
+        ls "$INPUT_PATH"
       shell: bash
       env:
         INPUT_PATH: ${{ inputs.path }}

--- a/playground/actions/compile/action.yml
+++ b/playground/actions/compile/action.yml
@@ -1,0 +1,13 @@
+name: 'Compile Playground repository'
+description: 'Compile a deploy-ready TUF metadata repository'
+inputs:
+  path:
+    description: 'Directory to create the metadata in'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - run: mkdir "$INPUT_PATH" && echo "test content..." >> "$INPUT_PATH/root.json"
+      shell: bash
+      env:
+        INPUT_PATH: ${{ inputs.path }}

--- a/playground/repo/README.md
+++ b/playground/repo/README.md
@@ -10,3 +10,5 @@ These commands are used by the signing-event GitHub action.
 
 `playground-status <known-good-directory> <event-name>`: Prints status of the signing event
 based on the changes done in the signing event and invites in .signing-event-state file
+
+`playground-publish <dir>`: Creates a deploy-ready metadata repository in the given directory

--- a/playground/repo/playground/__init__.py
+++ b/playground/repo/playground/__init__.py
@@ -1,1 +1,2 @@
+from playground.publish import publish
 from playground.status import status_cli

--- a/playground/repo/playground/publish.py
+++ b/playground/repo/playground/publish.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Google LLC
+
+"""Command line tool to compile a publishable TUF repository for Repository Playground CI"""
+
+import click
+import logging
+import os
+
+from playground._playground_repository import PlaygroundRepository
+
+
+@click.command()
+@click.option("-v", "--verbose", count=True, default=0)
+@click.argument("publish-dir")
+def publish(verbose: int, publish_dir: str) -> None:
+    """Create a metadata directory that is ready to publish
+    
+    In practice, creates versioned files for all metadata that is part of
+    the repository"""
+    logging.basicConfig(level=logging.WARNING - verbose * 10)
+
+    os.makedirs(publish_dir, exist_ok=True)
+    PlaygroundRepository("metadata").publish(publish_dir)

--- a/playground/repo/pyproject.toml
+++ b/playground/repo/pyproject.toml
@@ -18,4 +18,5 @@ dependencies = [
 ]
 
 [project.scripts]
+playground-publish = "playground:publish"
 playground-status = "playground:status_cli"


### PR DESCRIPTION
This action creates a metadata directory that is ready for client consumption:
* includes all versions of root
* uses versioned filenames for root, snapshot and targets and all delegated roles