### PR TITLE
Signer git-integration (commit+push)

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -81,24 +81,24 @@ If you intend to use Google Cloud KMS for online signing (instead of the default
 
 Both tools (`playground-delegate` and `playground-sign`) take one required argument, the
 signing event name (it is used as a git branch name). Typically the signing event exists
-and you know its name but in some cases (delegation, targetmodification) you can
-just choose a name for a new signing event: anything starting with "sign/" is fine.
+and you know its name but in some cases (delegation, target modification) you can choose
+a name for a new signing event: anything starting with "sign/" is fine.
 
 The tools will fetch the current signing event content from a matching branch in
-_pull-remote_. After signing or delegatation changes, the tools will push those changes
+_pull-remote_. After signing or delegatation changes, the tools will push the changes
 to matching branch on _push-remote_.
 
-Notes on remotes:
+Notes on remotes configured in `.playground-sign.ini`:
 * _pull-remote_ should always be the actual TUF repository
 * If you have permissions to push to the TUF repository, you can set _push-remote_ to same value
-* Otherwise you can set _push-remote_ to your fork: in this case you will have to make a PR
-  from your fork to the TUF repository after running the tool.
+* Otherwise you can set _push-remote_ to your fork: in this case after running the tools, you
+  should make a PR from your fork to the signing event branch on the TUF repository
 
 ### Initial signing event
 
 1. Run delegate tool to create initial metadata
    ```
-   playground-delegate sign/initialize
+   playground-delegate <event-name>
    ```
 1. Respond to the prompts
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -49,6 +49,10 @@ Whenever you run signing tools, you need a configuration file `.playground-sign.
    pykcs11lib = /usr/lib/x86_64-linux-gnu/libykcs11.so
    # GitHub username
    user-name = @my-github-username
+
+   # Git remotes to pull and push from
+   pull-remote = origin
+   push-remote = origin
    ```
 
 ### Setup a new Playground repository
@@ -75,36 +79,46 @@ If you intend to use Google Cloud KMS for online signing (instead of the default
 
 ## Operation
 
+Both tools (`playground-delegate` and `playground-sign`) take one required argument, the
+signing event name (it is used as a git branch name). Typically the signing event exists
+and you know its name but in some cases (delegation, targetmodification) you can
+just choose a name for a new signing event: anything starting with "sign/" is fine.
+
+The tools will fetch the current signing event content from a matching branch in
+_pull-remote_. After signing or delegatation changes, the tools will push those changes
+to matching branch on _push-remote_.
+
+Notes on remotes:
+* _pull-remote_ should always be the actual TUF repository
+* If you have permissions to push to the TUF repository, you can set _push-remote_ to same value
+* Otherwise you can set _push-remote_ to your fork: in this case you will have to make a PR
+  from your fork to the TUF repository after running the tool.
+
 ### Initial signing event
 
 1. Run delegate tool to create initial metadata
    ```
-   playground-delegate
+   playground-delegate sign/initialize
    ```
-1. Commit all changes in `metadata/`, push to a branch `sign/<signing-event-name>`
+1. Respond to the prompts
 
-This starts a signing event.
 
 ### Modify target files
 
 1. Add, remove or modify files under targets/ directory
 1. Run signer tool
    ```
-   playground-sign
+   playground-sign <event-name>
    ```
-1. Commit changes (both target files and metadata) and push to a branch `sign/<signing-event-name>`
-
-This starts a signing event.
+1. Respond to the prompts
 
 ### Add a delegation or modify an existing one
 
 1. Run delegate tool when you want to modify a roles delegation
    ```
-   playground-delegate <role>
+   playground-delegate <event-name> <role>
    ```
-1. Commit all changes in `metadata/`, push to a branch `sign/<signing-event-name>`
-
-This starts a signing event.
+1. Respond to the prompts
 
 ### Sign changes made by others
 
@@ -112,11 +126,9 @@ Signing should be done when the signing event (GitHub issue) asks for it:
 
 1. Run signer tool in the signing event branch
    ```
-   playground-sign
+   playground-sign <event-name>
    ```
-2. Commit metadata changes and push to a branch `sign/<signing-event-name>`
-
-This updates the signing event.
+1. Respond to the prompts
 
 ## Components
 
@@ -143,7 +155,6 @@ Various parts are still very experimental
 * output of the signing event is a work in progress
 * failures in the actions are not visible to user
 * testing is still completely manual
-* Several actions are hacks more than mature implementations 
 
 See [repo/](repo/), See [actions/](actions/)
 
@@ -152,7 +163,6 @@ See [repo/](repo/), See [actions/](actions/)
 Status:
 * playground-delegate mostly implented
 * playground-sign mostly implemented, althought output is a work in progress
-* Neither tool integrates git push/pull yet: at least for playground-sign integration would make a lot of sense
 
 See [signer/](signer/)
 

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -3,10 +3,16 @@
 """Common helper functions"""
 
 from configparser import ConfigParser
+from contextlib import contextmanager
+import os
 import subprocess
+from tempfile import TemporaryDirectory
+from typing import Generator
 import click
 
 from securesystemslib.signer import HSMSigner, Key
+
+from playground_sign._signer_repository import SignerRepository
 
 class SignerConfig:
     def __init__(self, path: str):
@@ -23,6 +29,40 @@ class SignerConfig:
             self.pull_remote = config["settings"]["push-remote"]
         except KeyError as e:
             raise click.ClickException(f"Failed to find required setting {e} in {path}")
+
+
+@contextmanager
+def signing_event(name: str, config: SignerConfig) -> Generator[SignerRepository, None, None]:
+    toplevel = git(["rev-parse", "--show-toplevel"])
+
+    # PyKCS11 (Yubikey support) needs the module path
+    # TODO: if config is not set, complain/ask the user?
+    if "PYKCS11LIB" not in os.environ:
+        os.environ["PYKCS11LIB"] = config.pykcs11lib
+
+    # first, make sure we're up-to-date
+    git(["fetch", config.pull_remote])
+    try:
+        git(["checkout", f"{config.pull_remote}/{name}"])
+    except subprocess.CalledProcessError:
+        click.echo("Remote branch not found: branching off from main")
+        git(["checkout", f"{config.pull_remote}/main"])
+
+    try:
+        # checkout the base of this signing event in another directory
+        with TemporaryDirectory() as temp_dir:
+            base_sha = git(["merge-base", f"{config.pull_remote}/main", "HEAD"])
+            git(["clone", "--quiet", toplevel, temp_dir])
+            git(["-C", temp_dir, "checkout", "--quiet", base_sha])
+            base_metadata_dir = os.path.join(temp_dir, "metadata")
+            metadata_dir = os.path.join(toplevel, "metadata")
+
+            repo = SignerRepository(metadata_dir, base_metadata_dir, config.user_name, get_secret_input)
+            yield repo
+    finally:
+        # go back to original branch
+        git(["checkout", "-"])
+
 
 def get_signing_key_input(message: str) -> Key:
     # TODO use value_proc argument to validate the input

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -8,6 +8,22 @@ import click
 
 from securesystemslib.signer import HSMSigner, Key
 
+class SignerConfig:
+    def __init__(self, path: str):
+        config = ConfigParser()
+        config.read(path)
+
+        # TODO: create config if missing, ask/confirm values from user
+        if not config:
+            raise click.ClickException(f"Settings file {path} not found")
+        try:
+            self.user_name = config["settings"]["user-name"]
+            self.pykcs11lib = config["settings"]["pykcs11lib"]
+            self.push_remote = config["settings"]["pull-remote"]
+            self.pull_remote = config["settings"]["push-remote"]
+        except KeyError as e:
+            raise click.ClickException(f"Failed to find required setting {e} in {path}")
+
 def get_signing_key_input(message: str) -> Key:
     # TODO use value_proc argument to validate the input
     click.prompt(message, default=True, show_default=False)
@@ -20,19 +36,8 @@ def get_signing_key_input(message: str) -> Key:
 
 
 def get_secret_input(secret: str, role: str) -> str:
-    return click.prompt(f"Enter {secret} to sign {role}", hide_input=True)
-
-
-def read_settings(config_path: str) -> tuple[str, str]:
-    config = ConfigParser()
-    config.read(config_path)
-    # TODO: create config if missing, ask user for values
-    if not config:
-        raise click.ClickException(f"Settings file {config_path} not found")
-    try:
-        return config["settings"]["user-name"], config["settings"]["pykcs11lib"]
-    except KeyError as e:
-        raise click.ClickException(f"Failed to find required setting {e} in {config_path}")
+    msg = f"Enter {secret} to sign {role}"
+    return click.prompt(msg, hide_input=True, show_default=False)
 
 
 def git(cmd: list[str]) -> str:

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -25,8 +25,8 @@ class SignerConfig:
         try:
             self.user_name = config["settings"]["user-name"]
             self.pykcs11lib = config["settings"]["pykcs11lib"]
-            self.push_remote = config["settings"]["pull-remote"]
-            self.pull_remote = config["settings"]["push-remote"]
+            self.push_remote = config["settings"]["push-remote"]
+            self.pull_remote = config["settings"]["pull-remote"]
         except KeyError as e:
             raise click.ClickException(f"Failed to find required setting {e} in {path}")
 

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -84,3 +84,7 @@ def git(cmd: list[str]) -> str:
     cmd = ["git"] + cmd
     proc = subprocess.run(cmd, capture_output=True, check=True, text=True)
     return proc.stdout.strip()
+
+def git_echo(cmd: list[str]):
+    cmd = ["git"] + cmd
+    subprocess.run(cmd, check=True, text=True)

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -139,7 +139,7 @@ class SignerRepository(Repository):
         # NOTE comparison is between target-files-on-disk vs current metadata-on-disk
         # So this state is for _local_ changes initiated by this user
         # * possibly the comparison should be against upstream branch metadata:
-        #   to cover the case of running the too lmultiple times
+        #   to cover the case of running the tool multiple times
         # * possibly similar functionality is required to present upstream change
         #   to signer to make an informed decision about signing
         target_dir = os.path.join(self._dir, "..", "targets")

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -44,8 +44,8 @@ class TargetState:
 
 @dataclass
 class OnlineConfig:
-    # All keys are use as singning keys for both snapshot and timestamp
-    keys: list[tuple[str, Key]]
+    # All keys are used as signing keys for both snapshot and timestamp
+    keys: list[Key]
     timestamp_expiry: int
     snapshot_expiry: int
 
@@ -314,9 +314,7 @@ class SignerRepository(Repository):
         snapshot_expiry = snapshot_role.unrecognized_fields["x-playground-expiry-period"]
         keys = []
         for keyid in timestamp_role.keyids:
-            key = root.get_key(keyid)
-            uri = key.unrecognized_fields["x-playground-online-uri"]
-            keys.append((uri, key))
+            keys.append(root.get_key(keyid))
 
         return OnlineConfig(keys, timestamp_expiry, snapshot_expiry)
 
@@ -334,8 +332,7 @@ class SignerRepository(Repository):
                 root.revoke_key(keyid, "snapshot")
 
             # Add new keys
-            for uri, key in online_config.keys:
-                key.unrecognized_fields["x-playground-online-uri"] = uri
+            for key in online_config.keys:
                 root.add_key(key, "timestamp")
                 root.add_key(key, "snapshot")
 

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -167,7 +167,7 @@ def _init_repository(repo: SignerRepository) -> bool:
     repo.set_online_config(online_config)
     return True
 
-def _update_online_roles(repo) -> bool:
+def _update_online_roles(repo: SignerRepository) -> bool:
     click.echo(f"Modifying online roles")
 
     config = repo.get_online_config()
@@ -210,9 +210,9 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
 
     toplevel = git(["rev-parse", "--show-toplevel"])
     settings_path = os.path.join(toplevel, ".playground-sign.ini")
-    config = SignerConfig(settings_path)
+    user_config = SignerConfig(settings_path)
 
-    with signing_event(event_name, config) as repo:
+    with signing_event(event_name, user_config) as repo:
         if repo.state == SignerState.UNINITIALIZED:
             changed = _init_repository(repo)
         else:
@@ -228,10 +228,10 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
             git(["add", f"metadata/{role}.json"])
             git(["commit", "-m", f"'{role}' role/delegation change", "--", "metadata"])
             if push:
-                msg = f"Press enter to push changes to {config.push_remote}/{event_name}"
+                msg = f"Press enter to push changes to {user_config.push_remote}/{event_name}"
                 click.prompt(msg, default=True, show_default=False)
-                git(["push", config.push_remote, f"HEAD:refs/heads/{event_name}"])
-                click.echo(f"Pushed branch {event_name} to {config.push_remote}")
+                git(["push", user_config.push_remote, f"HEAD:refs/heads/{event_name}"])
+                click.echo(f"Pushed branch {event_name} to {user_config.push_remote}")
             else:
                 # TODO: deal with existing branch?
                 click.echo(f"Creating local branch {event_name}")

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -215,12 +215,14 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
     with signing_event(event_name, config) as repo:
         if repo.state == SignerState.UNINITIALIZED:
             changed = _init_repository(repo)
-        elif role in ["timestamp", "snapshot"]:
-            changed = _update_online_roles(repo)
-        elif role:
-            changed =  _update_offline_role(repo, role)
         else:
-            raise click.UsageError("ROLE is required")
+            if role is None:
+                role = click.prompt("Enter name of role to modify")
+
+            if role in ["timestamp", "snapshot"]:
+                changed = _update_online_roles(repo)
+            else:
+                changed =  _update_offline_role(repo, role)
 
         if changed:
             git(["add", f"metadata/{role}.json"])

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -13,6 +13,7 @@ from securesystemslib.signer import GCPSigner, SigstoreKey, KEY_FOR_TYPE_AND_SCH
 from playground_sign._common import (
     get_signing_key_input,
     git,
+    git_echo,
     SignerConfig,
     signing_event,
 )
@@ -238,8 +239,7 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
             if push:
                 msg = f"Press enter to push changes to {user_config.push_remote}/{event_name}"
                 click.prompt(msg, default=True, show_default=False)
-                git(["push", user_config.push_remote, f"HEAD:refs/heads/{event_name}"])
-                click.echo(f"Pushed branch {event_name} to {user_config.push_remote}")
+                git_echo(["push", "--progress", user_config.push_remote, f"HEAD:refs/heads/{event_name}"])
             else:
                 # TODO: deal with existing branch?
                 click.echo(f"Creating local branch {event_name}")

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -9,6 +9,7 @@ import os
 from playground_sign._common import (
     get_signing_key_input,
     git,
+    git_echo,
     SignerConfig,
     signing_event,
 )
@@ -76,8 +77,7 @@ def sign(verbose: int, push: bool, event_name: str):
             if push:
                 msg = f"Press enter to push signature(s) to {user_config.push_remote}/{event_name}"
                 click.prompt(msg, default=True, show_default=False)
-                git(["push", user_config.push_remote, f"HEAD:refs/heads/{event_name}"])
-                click.echo(f"Pushed branch {event_name} to {user_config.push_remote}")
+                git_echo(["push", "--progress", user_config.push_remote, f"HEAD:refs/heads/{event_name}"])
             else:
                 # TODO: maybe deal with existing branch?
                 click.echo(f"Creating local branch {event_name}")


### PR DESCRIPTION
This is a work in progress to handle git fetch,commit & push within the tool.

It's not perfect but works when used appropriately
```
playground-sign EVENT-NAME
playground-delegate EVENT-NAME ROLE-NAME
```

It's a bit annoying that playground-sign now requires the event name but #64 is about removing that requirement