### PR TITLE
signing-event: Don't open PR, just offer a link

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -57,8 +57,7 @@ Whenver you run signing tools, you need a configuration file `.playground-sign.i
 
 ### Setup a new Playground repository
 
-1. Fork the [template](https://github.com/jku/playground-template). Enable
-   _Settings->Actions->Allow GitHub Actions to create and approve pull requests_.
+1. Fork the [template](https://github.com/jku/playground-template).
 1. To enable repository publishing, set _Settings->Pages->Source to `Github Actions`. `main`
    should be enabled as deployment branch in _Settings->Environments->GitHub Pages_.
 1. Make sure Google Cloud allows this repository OIDC identity to sign with a KMS key.

--- a/playground/actions/signing-event/action.yml
+++ b/playground/actions/signing-event/action.yml
@@ -56,24 +56,14 @@ runs:
           }
 
           if (process.env.STATUS == 'success') {
-            const prs = await github.rest.search.issuesAndPullRequests({
-              q: "head:" + process.env.GITHUB_REF_NAME + "+state:open+type:pr+repo:" + repo,
-            })
-            if (prs.data.total_count != 0) {
-              console.log("Skipping PR creation as one exists already")
-            } else {
-              const pull = await github.rest.pulls.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                head: process.env.GITHUB_REF_NAME,
-                base: 'main',
-                title: process.env.GITHUB_REF_NAME,
-                body: 'This is a Pull request for signing event ' + process.env.GITHUB_REF_NAME + '.\nCloses #' + process.env.ISSUE,
-              })
-              message += "### Pull request filed\n\n"
-              message += "Threshold of signatures has been reached. Pull request #" + pull.data.number + " has been filed."
-            }
+            pr_url = new URL("https://github.com/" + repo + "/compare/main..." + process.env.GITHUB_REF_NAME)
+            pr_url.searchParams.set("expand", "1")
+            pr_url.searchParams.set("title", "Signing event " + process.env.GITHUB_REF_NAME)
+            pr_url.searchParams.set("body", "Signing event " + process.env.GITHUB_REF_NAME + " is successful and ready to merge.\n\nCloses #" + issue + ".")
+            message += "### Signing event is successful\n\n"
+            message += "Threshold of signatures has been reached. A [pull request](" + pr_url + ") can be opened."
           }
+
           github.rest.issues.createComment({
             issue_number: issue,
             owner: context.repo.owner,


### PR DESCRIPTION
Two reasons:
* opening PRs via API requires non-default repository config
* maintainer may want to have more than threshold signatures as a policy, so automatically opening a PR is a bit premature