### PR TITLE
Use sigstore signing keys

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -21,7 +21,6 @@ This is a Work-In-Progress: any code should be seen as experimental for now. See
 
 Current signing requirements are:
  * A HW key with PIV support (such as a newer Yubikey)
- * Google Cloud KMS
 
 ### Setup signer
 
@@ -40,13 +39,10 @@ Current signing requirements are:
    ```
    pip install git+https://git@github.com/jku/repository-playground#subdirectory=playground/signer
    ```
-1. _(only needed for initial repository creation)_ Install
-   [gcloud](https://cloud.google.com/sdk/docs/install), authenticate (you need
-   _roles/cloudkms.publicKeyViewer_ permission)
 
 ### Configure signer
 
-Whenver you run signing tools, you need a configuration file `.playground-sign.ini` in the root dir of the git repository that contains the metadata:
+Whenever you run signing tools, you need a configuration file `.playground-sign.ini` in the root dir of the git repository that contains the metadata:
    ```
    [settings]
    # Path to PKCS#11 module
@@ -60,8 +56,22 @@ Whenver you run signing tools, you need a configuration file `.playground-sign.i
 1. Fork the [template](https://github.com/jku/playground-template).
 1. To enable repository publishing, set _Settings->Pages->Source to `Github Actions`. `main`
    should be enabled as deployment branch in _Settings->Environments->GitHub Pages_.
+
+#### Using a KMS
+
+If you intend to use Google Cloud KMS for online signing (instead of the default
+"ambient Sigstore signing"), there are a couple of extra steps:
 1. Make sure Google Cloud allows this repository OIDC identity to sign with a KMS key.
-   Insert the GCP authentication details into .github/workflows/snapshot.yml
+1. Define your GCP authentication details as repository variables in
+   _Settings->Secrets and variables->Actions->Variables_. Examples:
+   ```
+   GCP_WORKLOAD_IDENTITY_PROVIDER: projects/843741030650/locations/global/workloadIdentityPools/git-repo-demo/providers/git-repo-demo
+   GCP_SERVICE_ACCOUNT: git-repo-demo@python-tuf-kms.iam.gserviceaccount.com
+   ```
+1. _(only needed for initial repository creation)_ Install
+   [gcloud](https://cloud.google.com/sdk/docs/install) and authenticate in the
+   environment where you plan to run playground-delegate tool (you will need
+   _roles/cloudkms.publicKeyViewer_ permission)
 
 ## Operation
 
@@ -116,10 +126,6 @@ Status: Implemented in the playground-template project. Workflows include
 * signing-event
 * snapshot
 * version-bumps
-
-These are likely to still be changed:
-* KMS authentication will possibly move inside the actions
-* there may be a configuration file like `.github/playground.ini` that the actions can use to lookup e.g. KMS configuration 
 
 See [https://github.com/jku/playground-template]
 

--- a/playground/actions/online-version-bump/action.yml
+++ b/playground/actions/online-version-bump/action.yml
@@ -13,6 +13,14 @@ runs:
       with:
         path: repository
 
+    - name: Authenticate to Google Cloud
+      if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER && vars.GCP_SERVICE_ACCOUNT
+      uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d
+      with:
+        token_format: access_token
+        workload_identity_provider: vars.GCP_WORKLOAD_IDENTITY_PROVIDER
+        service_account: vars.GCP_SERVICE_ACCOUNT
+
     - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
       with:
         python-version: 3.11

--- a/playground/actions/snapshot/action.yml
+++ b/playground/actions/snapshot/action.yml
@@ -13,6 +13,14 @@ runs:
       with:
         path: repository
 
+    - name: Authenticate to Google Cloud
+      if: vars.GCP_WORKLOAD_IDENTITY_PROVIDER && vars.GCP_SERVICE_ACCOUNT
+      uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d
+      with:
+        token_format: access_token
+        workload_identity_provider: vars.GCP_WORKLOAD_IDENTITY_PROVIDER
+        service_account: vars.GCP_SERVICE_ACCOUNT
+
     - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
       with:
         python-version: 3.11

--- a/playground/repo/playground/snapshot.py
+++ b/playground/repo/playground/snapshot.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def _git(cmd: list[str]) -> subprocess.CompletedProcess:
     cmd = ["git", "-c", "user.name=repository-playground", "-c", "user.email=41898282+github-actions[bot]@users.noreply.github.com"] + cmd
-    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    proc = subprocess.run(cmd, check=True, text=True)
     logger.debug("%s:\n%s", cmd, proc.stdout)
     return proc
 

--- a/playground/repo/pyproject.toml
+++ b/playground/repo/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.0.1"
 description = "CI tools for Repository Plaground"
 readme = "README.md"
 dependencies = [
-  "securesystemslib[gcpkms]", 
+  "securesystemslib[gcpkms, sigstore] @ git+https://github.com//secure-systems-lab/securesystemslib", 
   "tuf @ git+https://github.com/theupdateframework/python-tuf",
   "click",
 ]

--- a/playground/signer/pyproject.toml
+++ b/playground/signer/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.0.1"
 description = "TUF signing tool for Repository Plaground"
 readme = "README.md"
 dependencies = [
-  "securesystemslib[gcpkms,hsm]", 
+  "securesystemslib[gcpkms,hsm,sigstore] @ git+https://github.com//secure-systems-lab/securesystemslib",
   "tuf @ git+https://github.com/theupdateframework/python-tuf",
   "click",
 ]


### PR DESCRIPTION
* Optionally (and by default) use sigstore for online signing
* choosing sigstore for online signing means two keys are added (because there are two workflows that need the keys)
* GCP authentication is now done only if the auth details are set in GH repository variables -- this means the auth needs to be removed from playground-template
* requires securesystemslib main