### PR TITLE
Use new repository annotations and accessors

### DIFF
--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -68,9 +68,9 @@ class PlaygroundRepository(Repository):
     def _get_keys(self, role: str) -> list[Key]:
         """Return public keys for delegated role"""
         if role in ["root", "timestamp", "snapshot", "targets"]:
-            delegator: Root|Targets = self.open("root").signed
+            delegator: Root|Targets = self.root()
         else:
-            delegator = self.open("targets").signed
+            delegator = self.targets()
 
         r = delegator.get_delegated_role(role)
         keys = []
@@ -160,11 +160,11 @@ class PlaygroundRepository(Repository):
         # are then exposed
         targets_files: dict[str, MetaFile] = {}
 
-        md:Metadata[Targets] = self.open("targets")
-        targets_files["targets.json"] = MetaFile(md.signed.version)
-        if md.signed.delegations and md.signed.delegations.roles:
-            for role in md.signed.delegations.roles.values():
-                version = self.open(role.name).signed.version
+        targets = self.targets()
+        targets_files["targets.json"] = MetaFile(targets.version)
+        if targets.delegations and targets.delegations.roles:
+            for role in targets.delegations.roles.values():
+                version = self.targets(role.name).version
                 targets_files[f"{role.name}.json"] = MetaFile(version)
 
         return targets_files
@@ -175,8 +175,7 @@ class PlaygroundRepository(Repository):
 
         Called by timestamp() when it needs current snapshot version
         """
-        md = self.open("snapshot")
-        return MetaFile(md.signed.version)
+        return MetaFile(self.snapshot().version)
 
     def open_prev(self, role:str) -> Metadata | None:
         """Return known good metadata for role (if it exists)"""
@@ -292,8 +291,8 @@ class PlaygroundRepository(Repository):
             shutil.copy(src_path, metadata_dir)
         shutil.copy(os.path.join(self._dir, "timestamp.json"), metadata_dir)
 
-        md: Metadata[Snapshot] = self.open("snapshot")
-        dst_path = os.path.join(metadata_dir, f"{md.signed.version}.snapshot.json")
+        snapshot = self.snapshot()
+        dst_path = os.path.join(metadata_dir, f"{snapshot.version}.snapshot.json")
         shutil.copy(os.path.join(self._dir, "snapshot.json"), dst_path)
 
         for filename, metafile  in md.signed.meta.items():

--- a/playground/repo/playground/bump_expiring.py
+++ b/playground/repo/playground/bump_expiring.py
@@ -40,7 +40,7 @@ def bump_online(verbose: int, push: bool, publish_dir: str|None) -> None:
     snapshot_version = repo.bump_expiring("snapshot")
     if snapshot_version is not None:
         # if snapshot changes, we need to actually update timestamp content
-        _, meta = repo.timestamp()
+        _, meta = repo.do_timestamp()
         assert meta
         timestamp_version = meta.version
         msg += f"snapshot v{snapshot_version}, timestamp v{timestamp_version}."

--- a/playground/repo/playground/snapshot.py
+++ b/playground/repo/playground/snapshot.py
@@ -36,12 +36,12 @@ def snapshot(verbose: int, push: bool, publish_dir: str|None) -> None:
     logging.basicConfig(level=logging.WARNING - verbose * 10)
 
     repo = PlaygroundRepository("metadata")
-    snapshot_updated, _ = repo.snapshot()
+    snapshot_updated, _ = repo.do_snapshot()
     if not snapshot_updated:
         click.echo("No snapshot needed")
         sys.exit(1)
 
-    repo.timestamp()
+    repo.do_timestamp()
 
     msg = "Snapshot & timestamp"
     _git(["add", "metadata/timestamp.json", "metadata/snapshot.json"])

--- a/playground/repo/pyproject.toml
+++ b/playground/repo/pyproject.toml
@@ -13,7 +13,7 @@ description = "CI tools for Repository Plaground"
 readme = "README.md"
 dependencies = [
   "securesystemslib[gcpkms, sigstore] @ git+https://github.com//secure-systems-lab/securesystemslib", 
-  "tuf @ git+https://github.com/theupdateframework/python-tuf@9d09c427c",
+  "tuf @ git+https://github.com/theupdateframework/python-tuf",
   "click",
 ]
 requires-python = ">=3.10"

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -275,7 +275,7 @@ class SignerRepository(Repository):
             if role in ["snapshot", "timestamp"]:
                 raise ValueError(f"Cannot create {role}")
             if role == "root":
-                md = Metadata(Root())
+                md: Metadata = Metadata(Root())
             else:
                 md = Metadata(Targets())
             md.signed.unrecognized_fields["x-playground-expiry-period"] = 0
@@ -364,7 +364,7 @@ class SignerRepository(Repository):
             timestamp.unrecognized_fields["x-playground-expiry-period"] = online_config.timestamp_expiry
             snapshot.unrecognized_fields["x-playground-expiry-period"] = online_config.snapshot_expiry
 
-    def get_role_config(self, rolename: str) -> OfflineConfig:
+    def get_role_config(self, rolename: str) -> OfflineConfig | None:
         """Read configuration for delegation and role from metadata"""
         if rolename in ["timestamp", "snapshot"]:
             raise ValueError("online roles not supported")
@@ -436,6 +436,7 @@ class SignerRepository(Repository):
                 role = delegator.get_delegated_role(rolename)
             except ValueError:
                 # Role does not exist yet: create delegation
+                assert isinstance(delegator, Targets)
                 role = DelegatedRole(rolename, [], 1, True, [f"{rolename}/*"])
                 if not delegator.delegations:
                     delegator.delegations = Delegations({}, {})
@@ -483,8 +484,8 @@ class SignerRepository(Repository):
         state_file_path = os.path.join(self._dir, ".signing-event-state")
         if self._invites:
             with open(state_file_path, "w") as f:
-                config = {"invites": self._invites}
-                f.write(json.dumps(config, indent=2))
+                state_file = {"invites": self._invites}
+                f.write(json.dumps(state_file, indent=2))
         elif os.path.exists(state_file_path):
             os.remove(state_file_path)
 

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -39,6 +39,7 @@ def sign(verbose: int, push: bool, event_name: str):
             for rolename in repo.invites.copy():
                 # Modify the delegation
                 role_config = repo.get_role_config(rolename)
+                assert role_config
                 repo.set_role_config(rolename, role_config, key)
 
                 # Sign the role we are now a signer for

--- a/playground/signer/pyproject.toml
+++ b/playground/signer/pyproject.toml
@@ -13,7 +13,7 @@ description = "TUF signing tool for Repository Plaground"
 readme = "README.md"
 dependencies = [
   "securesystemslib[gcpkms,hsm,sigstore] @ git+https://github.com/secure-systems-lab/securesystemslib",
-  "tuf @ git+https://github.com/theupdateframework/python-tuf@9d09c427c",
+  "tuf @ git+https://github.com/theupdateframework/python-tuf",
   "click",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
95% of this PR is using new annotated tuf.repository accessors:
* `Repository.root()` and `Repository.edit_root()` (and similar for other metadata types)
* renamed online methods: `do_snapshot()` and `do_timestamp()`

Since mypy now exposes some new issues, There are also some annotation tweaks to fix those 