### PR TITLE
Sigstore for maintainers

### DIFF
--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -11,7 +11,7 @@ from tempfile import TemporaryDirectory
 from typing import Generator
 import click
 
-from securesystemslib.signer import HSMSigner, Key
+from securesystemslib.signer import HSMSigner, Key, SigstoreSigner
 
 from playground_sign._signer_repository import SignerRepository
 
@@ -65,13 +65,41 @@ def signing_event(name: str, config: SignerConfig) -> Generator[SignerRepository
         git_expect(["checkout", "-"])
 
 
-def get_signing_key_input(message: str) -> Key:
-    # TODO use value_proc argument to validate the input
-    click.prompt(message, default=True, show_default=False)
-    try:
-        _, key = HSMSigner.import_()
-    except Exception as e:
-        raise click.ClickException(f"Failed to read HW key: {e}")
+def get_signing_key_input() -> Key:
+    choice = click.prompt(
+        f" 1. Sigstore (OpenID Connect)\n"
+        f" 2. Yubikey\n"
+        "Please choose the type of signing key you would like to use",
+        type=click.IntRange(1,2),
+        default=1,
+    )
+
+    if choice == 1:
+        identity = click.prompt("Please enter your email address")
+        issuer_id = click.prompt(
+            f" 1. GitHub\n"
+            f" 2. Google\n"
+            f" 3. Microsoft\n"
+            "Please choose the identity issuer",
+            type=click.IntRange(1,3),
+            default=1,
+        )
+        if issuer_id == 1:
+            issuer = "https://github.com/login/oauth"
+        elif issuer_id == 2:
+            issuer = "https://accounts.google.com"
+        else:
+            issuer = "https://login.microsoftonline.com"
+        try:
+            _, key = SigstoreSigner.import_(identity, issuer, ambient=False)
+        except Exception as e:
+            raise click.ClickException(f"Failed to create Sigstore key: {e}")
+    else:
+        click.prompt("Please insert your Yubikey and press enter:", default=True, show_default=False)
+        try:
+            _, key = HSMSigner.import_()
+        except Exception as e:
+            raise click.ClickException(f"Failed to read HW key: {e}")
 
     return key
 

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -66,21 +66,26 @@ def signing_event(name: str, config: SignerConfig) -> Generator[SignerRepository
 
 
 def get_signing_key_input() -> Key:
+    click.echo(
+        "\nConfiguring signing key\n"
+        " 1. Sigstore (OpenID Connect)\n"
+        " 2. Yubikey"
+    )
     choice = click.prompt(
-        f" 1. Sigstore (OpenID Connect)\n"
-        f" 2. Yubikey\n"
-        "Please choose the type of signing key you would like to use",
+        bold("Please choose the type of signing key you would like to use"),
         type=click.IntRange(1,2),
         default=1,
     )
 
     if choice == 1:
-        identity = click.prompt("Please enter your email address")
-        issuer_id = click.prompt(
+        identity = click.prompt(bold("Please enter your email address"))
+        click.echo(
             f" 1. GitHub\n"
             f" 2. Google\n"
-            f" 3. Microsoft\n"
-            "Please choose the identity issuer",
+            f" 3. Microsoft"
+        )
+        issuer_id = click.prompt(
+            bold("Please choose the identity issuer"),
             type=click.IntRange(1,3),
             default=1,
         )
@@ -95,7 +100,7 @@ def get_signing_key_input() -> Key:
         except Exception as e:
             raise click.ClickException(f"Failed to create Sigstore key: {e}")
     else:
-        click.prompt("Please insert your Yubikey and press enter:", default=True, show_default=False)
+        click.prompt(bold("Please insert your Yubikey and press enter"), default=True, show_default=False)
         try:
             _, key = HSMSigner.import_()
         except Exception as e:
@@ -111,7 +116,7 @@ def get_secret_input(secret: str, role: str) -> str:
     if not sys.stdin.isatty():
         return sys.stdin.readline().rstrip()
 
-    return click.prompt(msg, hide_input=True)
+    return click.prompt(bold(msg), hide_input=True)
 
 
 def git(cmd: list[str]) -> str:
@@ -130,3 +135,6 @@ def git_expect(cmd: list[str]) -> str:
 def git_echo(cmd: list[str]):
     cmd = ["git"] + cmd
     subprocess.run(cmd, check=True, text=True)
+
+def bold(text: str) -> str:
+    return click.style(text, bold=True)

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -13,7 +13,7 @@ import os
 from datetime import datetime, timedelta
 from typing import Callable
 from securesystemslib.exceptions import UnverifiedSignatureError
-from securesystemslib.signer import Signature, Signer
+from securesystemslib.signer import Signature, Signer, SigstoreKey, SigstoreSigner, KEY_FOR_TYPE_AND_SCHEME, SIGNER_FOR_URI_SCHEME
 
 from tuf.api.exceptions import UnsignedMetadataError
 from tuf.api.metadata import DelegatedRole, Delegations, Key, Metadata, Root, TargetFile, Targets
@@ -22,6 +22,10 @@ from tuf.repository import Repository, AbortEdit
 
 
 logger = logging.getLogger(__name__)
+
+KEY_FOR_TYPE_AND_SCHEME[("sigstore-oidc", "Fulcio")] = SigstoreKey
+SIGNER_FOR_URI_SCHEME[SigstoreSigner.SCHEME] = SigstoreSigner
+
 
 @unique
 class SignerState(Enum):
@@ -244,14 +248,17 @@ class SignerRepository(Repository):
         def secret_handler(secret: str) -> str:
             return self._get_secret(secret, role)
 
-        signer = Signer.from_priv_key_uri("hsm:", key, secret_handler)
+        # TODO Get key uri from .playground-sign.ini, avoid if-else here
+        if key.keytype == "sigstore-oidc":
+            signer = Signer.from_priv_key_uri("sigstore:?ambient=false", key, secret_handler)
+        else:
+            signer = Signer.from_priv_key_uri("hsm:", key, secret_handler)
         while True:
             try:
                 md.sign(signer, True)
                 break
             except UnsignedMetadataError:
                 print(f"Failed to sign {role} with {self.user_name} key. Try again?")
-
 
     def _write(self, role: str, md: Metadata) -> None:
         filename = self._get_filename(role)

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -11,6 +11,7 @@ import os
 from securesystemslib.signer import GCPSigner, SigstoreKey, SSlibKey, KEY_FOR_TYPE_AND_SCHEME
 
 from playground_sign._common import (
+    bold,
     get_signing_key_input,
     git_expect,
     git_echo,
@@ -38,10 +39,12 @@ def _get_offline_input(
     config = copy.deepcopy(config)
     click.echo(f"\nConfiguring role {role}")
     while True:
-        choice = click.prompt(
+        click.echo(
             f" 1. Configure signers: [{', '.join(config.signers)}], requiring {config.threshold} signatures\n"
-            f" 2. Configure expiry: Role expires in {config.expiry_period} days, re-signing starts {config.signing_period} days before expiry\n"
-            "Please choose an option or press enter to continue",
+            f" 2. Configure expiry: Role expires in {config.expiry_period} days, re-signing starts {config.signing_period} days before expiry"
+        )
+        choice = click.prompt(
+            bold("Please choose an option or press enter to continue"),
             type=click.IntRange(0, 2),
             default=0,
             show_default=False,
@@ -51,7 +54,7 @@ def _get_offline_input(
         if choice == 1:
             # TODO use value_proc argument to validate the input
             response = click.prompt(
-                f"Please enter list of {role} signers",
+                bold(f"Please enter list of {role} signers"),
                 default=", ".join(config.signers)
             )
             config.signers.clear()
@@ -66,18 +69,18 @@ def _get_offline_input(
             else:
                 # TODO use value_proc argument to validate threshold is [1-len(new_signers)]
                 config.threshold = click.prompt(
-                    f"Please enter {role} threshold",
+                    bold(f"Please enter {role} threshold"),
                     type=int,
                     default=config.threshold
                 )
         elif choice == 2:
             config.expiry_period = click.prompt(
-                f"Please enter {role} expiry period in days",
+                bold(f"Please enter {role} expiry period in days"),
                 type=int,
                 default=config.expiry_period,
             )
             config.signing_period = click.prompt(
-                f"Please enter {role} signing period in days",
+                bold(f"Please enter {role} signing period in days"),
                 type=int,
                 default=config.signing_period,
             )
@@ -114,11 +117,13 @@ def _get_online_input(
     click.echo(f"\nConfiguring online roles")
     while True:
         keyuri = config.keys[0].unrecognized_fields["x-playground-online-uri"]
-        choice = click.prompt(
+        click.echo(
             f" 1. Configure online key: {keyuri}\n"
             f" 2. Configure timestamp: Expires in {config.timestamp_expiry} days\n"
-            f" 3. Configure snapshot: Expires in {config.snapshot_expiry} days\n"
-            "Please choose an option or press enter to continue",
+            f" 3. Configure snapshot: Expires in {config.snapshot_expiry} days"
+        )
+        choice = click.prompt(
+            bold("Please choose an option or press enter to continue"),
             type=click.IntRange(0, 3),
             default=0,
             show_default=False,
@@ -128,7 +133,7 @@ def _get_online_input(
         if choice == 1:
             # TODO use value_proc argument to validate the input
             key_id = click.prompt(
-                "Press enter to use Sigstore, or enter a Google Cloud KMS key id",
+                bold("Press enter to use Sigstore, or enter a Google Cloud KMS key id"),
                 default=""
             )
             if key_id == "LOCAL_TESTING_KEY":
@@ -148,13 +153,13 @@ def _get_online_input(
                     raise click.ClickException(f"Failed to read Google Cloud KMS key: {e}")
         if choice == 2:
             config.timestamp_expiry = click.prompt(
-                f"Please enter timestamp expiry in days",
+                bold(f"Please enter timestamp expiry in days"),
                 type=int,
                 default=config.timestamp_expiry,
             )
         if choice == 3:
             config.snapshot_expiry = click.prompt(
-                f"Please enter snapshot expiry in days",
+                bold(f"Please enter snapshot expiry in days"),
                 type=int,
                 default=config.snapshot_expiry,
             )
@@ -232,7 +237,7 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
             changed = _init_repository(repo, user_config)
         else:
             if role is None:
-                role = click.prompt("Enter name of role to modify")
+                role = click.prompt(bold("Enter name of role to modify"))
 
             if role in ["timestamp", "snapshot"]:
                 changed = _update_online_roles(repo, user_config)
@@ -248,7 +253,7 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
             git_expect(["commit", "-m", msg, "--", "metadata"])
             if push:
                 msg = f"Press enter to push changes to {user_config.push_remote}/{event_name}"
-                click.prompt(msg, default=True, show_default=False)
+                click.prompt(bold(msg), default=True, show_default=False)
                 git_echo(["push", "--progress", user_config.push_remote, f"HEAD:refs/heads/{event_name}"])
             else:
                 # TODO: deal with existing branch?

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -175,7 +175,7 @@ def _init_repository(repo: SignerRepository, user_config: SignerConfig) -> bool:
 
     key = None
     if repo.user_name in root_config.signers or repo.user_name in targets_config.signers:
-        key = get_signing_key_input("Insert your HW key and press enter")
+        key = get_signing_key_input()
 
     repo.set_role_config("root", root_config, key)
     repo.set_role_config("targets", targets_config, key)
@@ -208,7 +208,7 @@ def _update_offline_role(repo: SignerRepository, role: str) -> bool:
 
     key = None
     if repo.user_name in new_config.signers:
-        key = get_signing_key_input("Insert your HW key and press enter")
+        key = get_signing_key_input()
 
     repo.set_role_config(role, new_config, key)
     return True

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -35,7 +35,7 @@ def sign(verbose: int, push: bool, event_name: str):
             changed = False
         elif repo.state == SignerState.INVITED:
             click.echo(f"You have been invited to become a signer for role(s) {repo.invites}.")
-            key = get_signing_key_input("To accept the invitation, please insert your HW key and press enter")
+            key = get_signing_key_input()
             for rolename in repo.invites.copy():
                 # Modify the delegation
                 role_config = repo.get_role_config(rolename)

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -7,6 +7,7 @@ import logging
 import os
 
 from playground_sign._common import (
+    bold,
     get_signing_key_input,
     git_expect,
     git_echo,
@@ -64,7 +65,7 @@ def sign(verbose: int, push: bool, event_name: str):
             for rolename, states in repo.target_changes.items():
                 for target_state in states.values():
                     click.echo(f"  {target_state.target.path} ({target_state.state.name})")
-            click.prompt("Press enter to approve these changes", default=True, show_default=False)
+            click.prompt(bold("Press enter to approve these changes"), default=True, show_default=False)
 
             repo.update_targets()
 
@@ -88,7 +89,7 @@ def sign(verbose: int, push: bool, event_name: str):
             git_expect(["commit", "-m", f"Signed by {user_config.user_name}"])
             if push:
                 msg = f"Press enter to push signature(s) to {user_config.push_remote}/{event_name}"
-                click.prompt(msg, default=True, show_default=False)
+                click.prompt(bold(msg), default=True, show_default=False)
                 git_echo(["push", "--progress", user_config.push_remote, f"HEAD:refs/heads/{event_name}"])
             else:
                 # TODO: maybe deal with existing branch?

--- a/playground/tests/e2e.sh
+++ b/playground/tests/e2e.sh
@@ -114,6 +114,7 @@ signer_init()
         "1"                 # Configure online roles? [1: configure key]
         "LOCAL_TESTING_KEY" # Enter key id
         ""                  # Configure online roles? [enter to continue]
+        "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW key and press enter
         "0000"              # sign root
         "0000"              # sign root
@@ -147,6 +148,7 @@ signer_init_shorter_snapshot_expiry()
         "3"                 # Configure online roles? [3: configure snapshot]
         "10"                 # Enter expiry [10 days]
         ""                  # Configure online roles? [enter to continue]
+        "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW key and press enter
         "0000"              # sign root
         "0000"              # sign root
@@ -184,6 +186,7 @@ signer_init_multiuser()
         "1"                 # Configure online roles? [1: configure key]
         "LOCAL_TESTING_KEY" # Enter key id
         ""                  # Configure online roles? [enter to continue]
+        "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW key and press enter
         "0000"              # sign targets
         ""                  # press enter to push
@@ -207,6 +210,7 @@ signer_accept_invite()
     export SOFTHSM2_CONF="$SIGNER_DIR/softhsm2.conf"
 
     INPUT=(
+        "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW and press enter
         "0000"              # sign targets
         "0000"              # sign targets


### PR DESCRIPTION
This is mostly to test the securesystemslib implementation:
* Allow using sigstore identity as maintainer key
* Add UI to ask for email and issuer if using sigstore identity
* Fix tests (but note that sigstore maintainer keys are not actually tested -- I think that is not easy)

TODO:
* should not ask for email and identity: should instead do the the token acquisition and read the token... Could do this as POC even before sigstore-python provides this (which I think they should)
* should verify when signing that the identity is the one we expect

cc @lukpueh 