### PR TITLE
Configurable signer expiry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
         cd playground/tests
         ./e2e.sh
 
+    - name: Run Playground unit tests
+      run: |
+        cd playground/repo
+        python -m unittest
+
     - name: Run tests with DEBUG_TESTS
       if: failure()
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Emacs backup files
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Emacs backup files
 *~
+__pycache__

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -123,7 +123,7 @@ class PlaygroundRepository(Repository):
             signing_days = signed.unrecognized_fields.get("x-playground-signing-period")
 
         if signing_days is None:
-            signing_days = max(1, expiry_days // 2)
+            signing_days = expiry_days // 2
 
         return (signing_days, expiry_days)
 

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -50,7 +50,7 @@ class SigningEventState:
 
 class PlaygroundRepository(Repository):
     """A online repository implementation for use in GitHub Actions
-    
+
     Arguments:
         dir: metadata directory to operate on
         prev_dir: optional known good repository directory
@@ -83,7 +83,7 @@ class PlaygroundRepository(Repository):
 
     def open(self, role:str) -> Metadata:
         """Return existing metadata, or create new metadata
-        
+
         This is an implementation of Repository.open()
         """
         fname = self._get_filename(role)
@@ -107,21 +107,41 @@ class PlaygroundRepository(Repository):
 
         return md
 
+
+    def signing_expiry_period(self, rolename: str, md: Metadata) -> tuple[int, int]:
+        """Extracts the signing and expiry period for a role
+
+        If no signing expiry is configured, half the expiry period is used.
+        """
+        if rolename in ["timestamp", "snapshot"]:
+            root_md:Metadata[Root] = self.open("root")
+            role = root_md.signed.roles[rolename]
+            expiry_days = role.unrecognized_fields["x-playground-expiry-period"]
+            # Add a try with 1/2 expiry days
+            try:
+                signing_days = role.unrecognized_fields["x-playground-signing-period"]
+            except KeyError:
+                signing_days = int(expiry_days / 2)
+        else:
+            expiry_days = md.signed.unrecognized_fields["x-playground-expiry-period"]
+            try:
+                signing_days = md.signed.unrecognized_fields["x-playground-signing-period"]
+            except KeyError:
+                signing_days = int(expiry_days / 2)
+
+        return (signing_days, expiry_days)
+
+
     def close(self, rolename: str, md: Metadata) -> None:
         """Write metadata to a file in repo dir
-        
+
         Implementation of Repository.close(). Signs online roles.
         """
         md.signed.version += 1
 
-        if rolename in ["timestamp", "snapshot"]:
-            root_md:Metadata[Root] = self.open("root")
-            role = root_md.signed.roles[rolename]
-            days = role.unrecognized_fields["x-playground-expiry-period"]
-        else:
-            days = md.signed.unrecognized_fields["x-playground-expiry-period"]
+        _, expiry_days = self.signing_expiry_period(rolename, md)
 
-        md.signed.expires = datetime.utcnow() + timedelta(days=days)
+        md.signed.expires = datetime.utcnow() + timedelta(days=expiry_days)
 
         md.signatures.clear()
         for key in self._get_keys(rolename):
@@ -261,7 +281,7 @@ class PlaygroundRepository(Repository):
     def status(self, rolename: str) -> tuple[SigningStatus, SigningStatus | None]:
         """Returns signing status for role.
 
-        In case of root, another SigningStatus is rturned for the previous root.
+        In case of root, another SigningStatus is returned for the previous root.
         Uses .signing-event-state file."""
         if rolename in ["timestamp", "snapshot"]:
             raise ValueError(f"Not supported for online metadata")
@@ -314,15 +334,10 @@ class PlaygroundRepository(Repository):
         """Create a new version of role if it is about to expire"""
         now = datetime.utcnow()
         bumped = True
+
         with self.edit(rolename) as signed:
-            if rolename in ["timestamp", "snapshot"]:
-                # TODO: should this be configurable as well?
-                # current value is 2 * cron period so we should get 3 attempts...
-                # but 13 hours is still not a lot if e.g. KMS breaks somehow
-                delta = timedelta(hours=13)
-            else:
-                days = signed.unrecognized_fields["x-playground-signing-period"]
-                delta = timedelta(days=days)
+            signing_days, _ = self.signing_expiry_period(rolename, signed)
+            delta = timedelta(days=signing_days)
 
             logger.debug(f"{rolename} signing period starts {signed.expires - delta}")
             if now + delta < signed.expires:

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -115,19 +115,13 @@ class PlaygroundRepository(Repository):
         """
         if rolename in ["timestamp", "snapshot"]:
             root_md:Metadata[Root] = self.open("root")
-            role = root_md.signed.roles[rolename]
-            expiry_days = role.unrecognized_fields["x-playground-expiry-period"]
-            # Add a try with 1/2 expiry days
-            try:
-                signing_days = role.unrecognized_fields["x-playground-signing-period"]
-            except KeyError:
-                signing_days = int(expiry_days / 2)
-        else:
-            expiry_days = md.unrecognized_fields["x-playground-expiry-period"]
-            try:
-                signing_days = md.unrecognized_fields["x-playground-signing-period"]
-            except KeyError:
-                signing_days = int(expiry_days / 2)
+            md = root_md.signed.roles[rolename]
+
+        expiry_days = md.unrecognized_fields["x-playground-expiry-period"]
+        try:
+            signing_days = md.unrecognized_fields["x-playground-signing-period"]
+        except KeyError:
+            signing_days = int(expiry_days / 2)
 
         return (signing_days, expiry_days)
 

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -158,6 +158,7 @@ class PlaygroundRepository(Repository):
                 md.signatures[key.keyid] = Signature(key.keyid, "")
 
         if rolename in ["timestamp", "snapshot"]:
+            root_md:Metadata[Root] = self.open("root")
             # repository should never write unsigned online roles
             root_md.verify_delegate(rolename, md)
 

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -123,9 +123,9 @@ class PlaygroundRepository(Repository):
             except KeyError:
                 signing_days = int(expiry_days / 2)
         else:
-            expiry_days = md.signed.unrecognized_fields["x-playground-expiry-period"]
+            expiry_days = md.unrecognized_fields["x-playground-expiry-period"]
             try:
-                signing_days = md.signed.unrecognized_fields["x-playground-signing-period"]
+                signing_days = md.unrecognized_fields["x-playground-signing-period"]
             except KeyError:
                 signing_days = int(expiry_days / 2)
 
@@ -139,7 +139,7 @@ class PlaygroundRepository(Repository):
         """
         md.signed.version += 1
 
-        _, expiry_days = self.signing_expiry_period(rolename, md)
+        _, expiry_days = self.signing_expiry_period(rolename, md.signed)
 
         md.signed.expires = datetime.utcnow() + timedelta(days=expiry_days)
 

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -123,6 +123,8 @@ class PlaygroundRepository(Repository):
 
         expiry_days = md.unrecognized_fields["x-playground-expiry-period"]
         try:
+            # For now set the signing period automatically if not set.
+            # For a future release this can be made mandatory.
             signing_days = md.unrecognized_fields["x-playground-signing-period"]
         except KeyError:
             signing_days = int(expiry_days / 2)

--- a/playground/repo/test/test_playground_reposiory.py
+++ b/playground/repo/test/test_playground_reposiory.py
@@ -2,12 +2,6 @@ import unittest, shutil, tempfile
 from playground._playground_repository import PlaygroundRepository
 
 class TestPlaygroundRepository(unittest.TestCase):
-    def setUp(self):
-        self.test_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.test_dir)
-
     def test_non_existing_repo(self):
         repo = PlaygroundRepository("/tmp/no_such_file")
         self.assertRaises(ValueError, repo.open, "root")

--- a/playground/repo/test/test_playground_reposiory.py
+++ b/playground/repo/test/test_playground_reposiory.py
@@ -1,0 +1,43 @@
+import unittest, shutil, tempfile
+from playground._playground_repository import PlaygroundRepository
+
+class TestPlaygroundRepository(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_non_existing_repo(self):
+        repo = PlaygroundRepository("/tmp/no_such_file")
+        self.assertRaises(ValueError, repo.open, "root")
+
+    def test_signing_expiry_days_root(self):
+        repo = PlaygroundRepository("test/test_repo1")
+        root = repo.open("root")
+
+        signing_days, expiry_days = repo.signing_expiry_period("root", root)
+        self.assertEqual(signing_days, 60)
+        self.assertEqual(expiry_days, 365)
+
+    def test_signing_expiry_days_role(self):
+        repo = PlaygroundRepository("test/test_repo2")
+
+        signing_days, expiry_days = repo.signing_expiry_period("timestamp", None)
+        self.assertEqual(signing_days, 6)
+        self.assertEqual(expiry_days, 40)
+
+    def test_default_signing_days(self):
+        repo = PlaygroundRepository("test/test_repo1")
+
+        signing_days, expiry_days = repo.signing_expiry_period("timestamp", None)
+        self.assertEqual(signing_days, 2)
+        self.assertEqual(expiry_days, 4)
+
+    # def test_bump_expires_expired(self):
+    #     repo = PlaygroundRepository("test/test_repo1")
+    #     ver = repo.bump_expiring("timestamp")
+    #     self.assertEqual(ver, 2)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/playground/repo/test/test_playground_reposiory.py
+++ b/playground/repo/test/test_playground_reposiory.py
@@ -8,23 +8,29 @@ class TestPlaygroundRepository(unittest.TestCase):
 
     def test_signing_expiry_days_root(self):
         repo = PlaygroundRepository("test/test_repo1")
-        root = repo.open("root")
 
-        signing_days, expiry_days = repo.signing_expiry_period("root", root.signed)
+        signing_days, expiry_days = repo.signing_expiry_period("root")
         self.assertEqual(signing_days, 60)
         self.assertEqual(expiry_days, 365)
+
+    def test_signing_expiry_days_targets(self):
+        repo = PlaygroundRepository("test/test_repo1")
+
+        signing_days, expiry_days = repo.signing_expiry_period("targets")
+        self.assertEqual(signing_days, 40)
+        self.assertEqual(expiry_days, 123)
 
     def test_signing_expiry_days_role(self):
         repo = PlaygroundRepository("test/test_repo2")
 
-        signing_days, expiry_days = repo.signing_expiry_period("timestamp", None)
+        signing_days, expiry_days = repo.signing_expiry_period("timestamp")
         self.assertEqual(signing_days, 6)
         self.assertEqual(expiry_days, 40)
 
     def test_default_signing_days(self):
         repo = PlaygroundRepository("test/test_repo1")
 
-        signing_days, expiry_days = repo.signing_expiry_period("timestamp", None)
+        signing_days, expiry_days = repo.signing_expiry_period("timestamp")
         self.assertEqual(signing_days, 2)
         self.assertEqual(expiry_days, 4)
 

--- a/playground/repo/test/test_playground_reposiory.py
+++ b/playground/repo/test/test_playground_reposiory.py
@@ -16,7 +16,7 @@ class TestPlaygroundRepository(unittest.TestCase):
         repo = PlaygroundRepository("test/test_repo1")
         root = repo.open("root")
 
-        signing_days, expiry_days = repo.signing_expiry_period("root", root)
+        signing_days, expiry_days = repo.signing_expiry_period("root", root.signed)
         self.assertEqual(signing_days, 60)
         self.assertEqual(expiry_days, 365)
 

--- a/playground/repo/test/test_repo1/root.json
+++ b/playground/repo/test/test_repo1/root.json
@@ -1,0 +1,63 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2022-02-03T01:02:03Z",
+  "keys": {
+   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-playground-keyowner": "@playgrounduser1"
+   },
+   "fa47289": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
+    },
+    "scheme": "ed25519",
+    "x-playground-online-uri": "envvar:LOCAL_TESTING_KEY"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 365
+   },
+   "targets": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 4
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1,
+  "x-playground-expiry-period": 365,
+  "x-playground-signing-period": 60
+ }
+}

--- a/playground/repo/test/test_repo1/targets.json
+++ b/playground/repo/test/test_repo1/targets.json
@@ -1,0 +1,17 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "targets",
+  "expires": "2022-02-03T01:02:03Z",
+  "spec_version": "1.0.31",
+  "targets": {},
+  "version": 1,
+  "x-playground-expiry-period": 123,
+  "x-playground-signing-period": 40
+ }
+}

--- a/playground/repo/test/test_repo1/timestamp.json
+++ b/playground/repo/test/test_repo1/timestamp.json
@@ -1,0 +1,19 @@
+{
+ "signatures": [
+  {
+   "keyid": "fa47289",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "timestamp",
+  "expires": "2021-02-04T01:02:03Z",
+  "meta": {
+   "snapshot.json": {
+    "version": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1
+ }
+}

--- a/playground/repo/test/test_repo2/root.json
+++ b/playground/repo/test/test_repo2/root.json
@@ -1,0 +1,64 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2022-02-03T01:02:03Z",
+  "keys": {
+   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-playground-keyowner": "@playgrounduser1"
+   },
+   "fa47289": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
+    },
+    "scheme": "ed25519",
+    "x-playground-online-uri": "envvar:LOCAL_TESTING_KEY"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 365
+   },
+   "targets": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+     "x-playground-expiry-period": 40,
+     "x-playground-signing-period": 6
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1,
+  "x-playground-expiry-period": 365,
+  "x-playground-signing-period": 60
+ }
+}

--- a/playground/repo/test/test_repo2/timestamp.json
+++ b/playground/repo/test/test_repo2/timestamp.json
@@ -1,0 +1,19 @@
+{
+ "signatures": [
+  {
+   "keyid": "fa47289",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "timestamp",
+  "expires": "2021-02-04T01:02:03Z",
+  "meta": {
+   "snapshot.json": {
+    "version": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1
+ }
+}


### PR DESCRIPTION
Any role can now configure `x-playground-signer-period` which is then used during bumping of metadata version to decide if the version should be bumped or not. If the `x-playground-signer-period` is not set, half the `x-playground-expiry-period` is used.

