### PR TITLE
Targets management version 4

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -111,27 +111,18 @@ Notes on remotes configured in `.playground-sign.ini`:
 
 ### Modify target files
 
-1. Make target file changes in the signing event git branch
-   * Choose a signing event name, create a branch
-     ```
-     git fetch origin
-     git switch -C sign/my-target-changes origin/main
-     ```
-   * Make changes with tools of your choosing:
-     ```
-     echo "test content" > targets/file.txt
-     git add targets/file.txt
-     git commit -m "Add a target file"
-     ```
-   * Submit changes to a signing event branch on the repository (by pushing to repository
-     or by using a PR to a signing event branch): This starts a signing event
-     ```
-     git push origin sign/my-target-changes
-     ```
-1. Update targets metadata
-   ```
-   playground-sign sign/my-target-changes
-   ```
+Make target file changes in the signing event git branch using tools and review processes
+of your choice.
+
+```
+git fetch origin
+git switch -C sign/my-target-changes origin/main
+echo "test content" > targets/file.txt
+git commit -m "Add a target file" -- targets/file.txt
+git push origin sign/my-target-changes
+```
+
+This starts a signing event (or updates an existing signing event).
 
 ### Sign changes made by others
 

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -256,7 +256,8 @@ class PlaygroundRepository(Repository):
 
         return True, None
 
-    def _build_targets(self, target_dir: str, rolename: str) -> dict[str, TargetFile]:
+    @staticmethod
+    def _build_targets(target_dir: str, rolename: str) -> dict[str, TargetFile]:
         """Build a roles dict of TargetFile based on target files in a directory"""
         targetfiles = {}
 

--- a/playground/repo/playground/bump_expiring.py
+++ b/playground/repo/playground/bump_expiring.py
@@ -14,7 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 def _git(cmd: list[str]) -> subprocess.CompletedProcess:
-    cmd = ["git", "-c", "user.name=repository-playground", "-c", "user.email=41898282+github-actions[bot]@users.noreply.github.com"] + cmd
+    cmd = [
+        "git",
+        "-c",
+        "user.name=repository-playground",
+        "-c",
+        "user.email=41898282+github-actions[bot]@users.noreply.github.com",
+    ] + cmd
     proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
     logger.debug("%s:\n%s", cmd, proc.stdout)
     return proc
@@ -24,7 +30,7 @@ def _git(cmd: list[str]) -> subprocess.CompletedProcess:
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("--push/--no-push", default=False)
 @click.argument("publish-dir", required=False)
-def bump_online(verbose: int, push: bool, publish_dir: str|None) -> None:
+def bump_online(verbose: int, push: bool, publish_dir: str | None) -> None:
     """Commit new metadata versions for online roles if needed
 
     New versions will be signed.
@@ -54,7 +60,9 @@ def bump_online(verbose: int, push: bool, publish_dir: str|None) -> None:
         sys.exit(1)
 
     click.echo(msg)
-    _git(["commit", "-m", msg, "--", "metadata/timestamp.json", "metadata/snapshot.json"])
+    _git(
+        ["commit", "-m", msg, "--", "metadata/timestamp.json", "metadata/snapshot.json"]
+    )
     if push:
         _git(["push", "origin", "HEAD"])
 
@@ -78,12 +86,12 @@ def bump_offline(verbose: int, push: bool) -> None:
     logging.basicConfig(level=logging.WARNING - verbose * 10)
 
     repo = PlaygroundRepository("metadata")
-    events=[]
+    events = []
     for filename in glob("*.json", root_dir="metadata"):
         if filename in ["timestamp.json", "snapshot.json"]:
             continue
 
-        rolename = filename[:-len(".json")]
+        rolename = filename[: -len(".json")]
         version = repo.bump_expiring(rolename)
         if version is None:
             logging.debug("No version bump needed for %s", rolename)

--- a/playground/repo/playground/snapshot.py
+++ b/playground/repo/playground/snapshot.py
@@ -14,7 +14,13 @@ logger = logging.getLogger(__name__)
 
 
 def _git(cmd: list[str]) -> subprocess.CompletedProcess:
-    cmd = ["git", "-c", "user.name=repository-playground", "-c", "user.email=41898282+github-actions[bot]@users.noreply.github.com"] + cmd
+    cmd = [
+        "git",
+        "-c",
+        "user.name=repository-playground",
+        "-c",
+        "user.email=41898282+github-actions[bot]@users.noreply.github.com",
+    ] + cmd
     proc = subprocess.run(cmd, check=True, text=True)
     logger.debug("%s:\n%s", cmd, proc.stdout)
     return proc
@@ -24,7 +30,7 @@ def _git(cmd: list[str]) -> subprocess.CompletedProcess:
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("--push/--no-push", default=False)
 @click.argument("publish-dir", required=False)
-def snapshot(verbose: int, push: bool, publish_dir: str|None) -> None:
+def snapshot(verbose: int, push: bool, publish_dir: str | None) -> None:
     """Update The TUF snapshot based on current repository content
 
     Create a commit with the snapshot and timestamp changes (if any).

--- a/playground/repo/playground/status.py
+++ b/playground/repo/playground/status.py
@@ -18,17 +18,21 @@ logger = logging.getLogger(__name__)
 
 def _git(cmd: list[str]) -> subprocess.CompletedProcess:
     cmd = ["git", "-c", "user.name=repository-playground", "-c", "user.email=41898282+github-actions[bot]@users.noreply.github.com"] + cmd
-    proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
-    logger.debug("%s:\n%s", cmd, proc.stdout)
-    return proc
+    try:
+        proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        logger.debug("%s:\n%s", cmd, proc.stdout)
+        return proc
+    except subprocess.CalledProcessError as e:
+        print ("Git output on error:", e.stdout, e.stderr)
+        raise e
 
 
-def _find_changed_roles(known_good_dir: str, signing_event_dir: str) -> list[str]:
+def _find_changed_roles(known_good_dir: str, signing_event_dir: str) -> set[str]:
     # find the files that have changed or been added
-    # TODO what about removed?
+    # TODO what about removed roles?
 
     files = glob("*.json", root_dir=signing_event_dir)
-    changed_roles = []
+    changed_roles = set()
     for fname in files:
         if (
             not os.path.exists(f"{known_good_dir}/{fname}") or
@@ -37,13 +41,33 @@ def _find_changed_roles(known_good_dir: str, signing_event_dir: str) -> list[str
             if fname in ["timestamp.json", "snapshot.json"]:
                 assert("Unexpected change in online files")
 
-            changed_roles.append(fname[:-len(".json")])
+            changed_roles.add(fname[:-len(".json")])
 
-    # reorder, toplevels first
-    for toplevel in ["targets", "root"]:
-        if toplevel in changed_roles:
-            changed_roles.remove(toplevel)
-            changed_roles.insert(0, toplevel)
+    return changed_roles
+
+
+def _find_changed_target_roles(known_good_targets_dir: str, targets_dir: str) -> set[str]:
+    files = (
+        glob("*", root_dir=targets_dir) +
+        glob("*/*", root_dir=targets_dir) +
+        glob("*", root_dir=known_good_targets_dir) +
+        glob("*/*", root_dir=known_good_targets_dir)
+    )
+    changed_roles = set()
+    for filepath in files:
+        f1 = os.path.join(targets_dir, filepath)
+        f2 = os.path.join(known_good_targets_dir, filepath)
+        try:
+            if filecmp.cmp(f1 ,f2, shallow=False):
+                continue
+        except FileNotFoundError:
+            pass
+
+        # we've found a changed target, add the rolename to list. Handle "targets" as special case
+        rolename, _, _ = filepath.rpartition(filepath)
+        if not rolename:
+            rolename = "targets"
+        changed_roles.add(rolename)
 
     return changed_roles
 
@@ -61,32 +85,45 @@ def _role_status(repo: PlaygroundRepository, role:str, event_name) -> bool:
         signed = signed | prev_status.signed
         missing = missing | prev_status.missing
 
+    if role_is_valid and not status.invites:
+        emoji = "heavy_check_mark"
+    else:
+        emoji = "x"
+    click.echo(f"#### :{emoji}: {role}")
+
     if status.invites:
-        click.echo(f"#### :x: {role}")
         click.echo(f"{role} delegations have open invites ({', '.join(status.invites)}).")
         click.echo(f"Invitees can accept the invitations by running `playground-sign {event_name}`")
-    elif role_is_valid:
-        click.echo(f"#### :heavy_check_mark: {role}")
-        click.echo(f"{role} is verified and signed by {sig_counts} signers ({', '.join(signed)}).")
-    elif signed:
-        click.echo(f"#### :x:{role}")
-        click.echo(f"{role} is not yet verified. It is signed by {sig_counts} signers ({', '.join(signed)}).")
-    else:
-        click.echo(f"#### :x: {role}")
-        click.echo(f"{role} is unsigned and not yet verified")
+
+    if not status.invites:
+        if status.target_changes:
+            click.echo(f"{role} contains following target file changes:")
+            for target_state in status.target_changes:
+                click.echo(f" * {target_state}")
+            click.echo("")
+
+
+        if role_is_valid:
+            click.echo(f"{role} is verified and signed by {sig_counts} signers ({', '.join(signed)}).")
+        elif signed:
+            click.echo(f"{role} is not yet verified. It is signed by {sig_counts} signers ({', '.join(signed)}).")
+        else:
+            click.echo(f"{role} is unsigned and not yet verified")
+
+        if missing:
+            click.echo(f"Still missing signatures from {', '.join(missing)}")
+            click.echo(f"Signers can sign these changes by running `playground-sign {event_name}`")
 
     if status.message:
         click.echo(f"**Error**: {status.message}")
-    elif missing and not status.invites:
-        click.echo(f"Still missing signatures from {', '.join(missing)}")
-        click.echo(f"Signers can sign these changes by running `playground-sign {event_name}`")
 
-    return role_is_valid and len(status.invites) == 0
+    return role_is_valid and not status.invites
 
 
 @click.command()
 @click.option("-v", "--verbose", count=True, default=0)
-def status(verbose: int) -> None:
+@click.option("--push/--no-push", default=True)
+def status(verbose: int, push: bool) -> None:
     """Status markdown output tool for Repository Playground CI"""
     logging.basicConfig(level=logging.WARNING - verbose * 10)
 
@@ -110,14 +147,32 @@ def status(verbose: int) -> None:
         _git(["clone", "--quiet", ".", known_good_dir])
         _git(["-C", known_good_dir, "checkout", "--quiet", merge_base])
 
-        good_dir = os.path.join(known_good_dir, "metadata")
+        good_metadata = os.path.join(known_good_dir, "metadata")
+        good_targets = os.path.join(known_good_dir, "targets")
         success = True
 
         # Compare current repository and the known good version.
         # Print status for each role, count invalid roles
-        repo = PlaygroundRepository("metadata", good_dir)
-        for role in _find_changed_roles(good_dir, "metadata"):
+        repo = PlaygroundRepository("metadata", good_metadata)
+
+        roles = list(_find_changed_roles(good_metadata, "metadata") | _find_changed_target_roles(good_targets, "targets"))
+
+        # reorder, toplevels first
+        for toplevel in ["targets", "root"]:
+            if toplevel in roles:
+                roles.remove(toplevel)
+                roles.insert(0, toplevel)
+
+        for role in roles:
+            if repo.update_targets(role):
+                # metadata and target content are not in sync: make a commit with metadata changes
+                msg = f"Update targets metadata for role {role}"
+                _git(["commit", "-m", msg, "--", f"metadata/{role}.json"])
+
             if not _role_status(repo, role, event_name):
                 success = False
+
+    if push:
+        _git(["push", "origin", event_name])
 
     sys.exit(0 if success else 1)

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -14,7 +14,7 @@ from playground_sign._common import (
     SignerConfig,
     signing_event,
 )
-from playground_sign._signer_repository import SignerState, State
+from playground_sign._signer_repository import SignerState
 
 logger = logging.getLogger(__name__)
 
@@ -53,15 +53,6 @@ def sign(verbose: int, push: bool, event_name: str):
                 for rolename in repo.unsigned:
                     click.echo(repo.status(rolename))
                     repo.sign(rolename)
-            changed = True
-        elif repo.state == SignerState.TARGETS_CHANGED:
-            click.echo(f"Target file changes have been found in this signing event:")
-            for rolename, states in repo.target_changes.items():
-                for target_state in states.values():
-                    click.echo(f"  {target_state.target.path} ({target_state.state.name})")
-            click.prompt(bold("Press enter to approve these changes"), default=True, show_default=False)
-
-            repo.update_targets()
             changed = True
         elif repo.state == SignerState.SIGNATURE_NEEDED:
             click.echo(f"Your signature is requested for role(s) {repo.unsigned}.")

--- a/playground/tests/expected/target-file-changes/metadata/2.snapshot.json
+++ b/playground/tests/expected/target-file-changes/metadata/2.snapshot.json
@@ -10,7 +10,7 @@
   "expires": "2022-02-03T01:02:03Z",
   "meta": {
    "targets.json": {
-    "version": 2
+    "version": 3
    }
   },
   "spec_version": "1.0.31",

--- a/playground/tests/expected/target-file-changes/metadata/3.targets.json
+++ b/playground/tests/expected/target-file-changes/metadata/3.targets.json
@@ -21,7 +21,7 @@
     "length": 15
    }
   },
-  "version": 2,
+  "version": 3,
   "x-playground-expiry-period": 365,
   "x-playground-signing-period": 60
  }


### PR DESCRIPTION
Redesign targets management once more:
* Users still make target content changes (outside of the tool)
* Let repository do the actual metadata changes during signing-event (the method is called status() but signing_event_update() might be better)
* Repository also documents the target changes at high level in the signing event
* Users sign normally: "playground-sign <EVENT>"

This makes the UX cleaner and does not complicate the repository too much.

The expected targets metadata change in e2e tests is because the PlaygroundRepository does not figure out version numbers as smartly as SignerRepository does, and ends up bumping versions more than needed: this could be fixed but it's not critical targets metadata.

This change means "playground-status" now makes commits and pushes them to signing event branch. This means the commands name is now not very descriptive. Changing it should not be disruptive but I did not want to grow this PR, so leaving that for later.