### PR TITLE
Improve playground-sign output

### DIFF
--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -53,11 +53,13 @@ def signing_event(name: str, config: SignerConfig) -> Generator[SignerRepository
         # checkout the base of this signing event in another directory
         with TemporaryDirectory() as temp_dir:
             base_sha = git_expect(["merge-base", f"{config.pull_remote}/main", "HEAD"])
+            event_sha = git_expect(["rev-parse", "HEAD"])
             git_expect(["clone", "--quiet", toplevel, temp_dir])
             git_expect(["-C", temp_dir, "checkout", "--quiet", base_sha])
             base_metadata_dir = os.path.join(temp_dir, "metadata")
             metadata_dir = os.path.join(toplevel, "metadata")
 
+            click.echo(bold_blue(f"Signing event {name} (commit {event_sha[:7]})"))
             repo = SignerRepository(metadata_dir, base_metadata_dir, config.user_name, get_secret_input)
             yield repo
     finally:

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -110,7 +110,12 @@ def get_signing_key_input() -> Key:
 
 
 def get_secret_input(secret: str, role: str) -> str:
-    msg = f"Enter {secret} to sign {role}"
+    # TODO: Fix this so it prints role as well
+    # This currently has an issue when it's called from
+    # SignerRepository._sign(): The role name is always whatever the first calls argument was...
+    # It seems like the role variable becomes part of the closure in _sign() somehow and then
+    # the role value gets reused in later calls.
+    msg = f"Enter {secret} to sign"
 
     # special case for tests -- prompt() will lockup trying to hide STDIN:
     if not sys.stdin.isatty():
@@ -138,3 +143,6 @@ def git_echo(cmd: list[str]):
 
 def bold(text: str) -> str:
     return click.style(text, bold=True)
+
+def bold_blue(text: str) -> str:
+    return click.style(text, bold=True, fg="bright_blue")

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -548,7 +548,9 @@ class SignerRepository(Repository):
             signed = self.root()
             delegations = signed.roles
             old_signed = self._known_good_root()
-            old_delegations = old_signed.roles
+            # avoid using the default delegations for initial old_delegations
+            if signed.version > 1:
+                old_delegations = old_signed.roles
 
             # Use timestamp output for both snapshot and timestamp: NOTE: we should validate that
             # the delegations really are identical

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -298,11 +298,13 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
             if role:
                 msg = f"'{role}' role/delegation change"
             else:
-                msg = "Initial offline metadata"
+                msg = "Initial root and targets"
             git_expect(["add", "metadata/"])
             git_expect(["commit", "-m", msg, "--", "metadata"])
 
             if repo.unsigned:
+                click.echo(f"Your signature is required for role(s) {repo.unsigned}.")
+
                 for rolename in repo.unsigned:
                     click.echo(repo.status(rolename))
                     repo.sign(rolename)

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -8,6 +8,7 @@ import os
 
 from playground_sign._common import (
     bold,
+    bold_blue,
     get_signing_key_input,
     git_expect,
     git_echo,
@@ -31,6 +32,8 @@ def sign(verbose: int, push: bool, event_name: str):
     user_config = SignerConfig(settings_path)
 
     with signing_event(event_name, user_config) as repo:
+        git_hash = git_expect(["rev-parse", "HEAD"])
+        click.echo(bold_blue(f"Signing event {event_name} (commit {git_hash[:7]})"))
         if repo.state == SignerState.UNINITIALIZED:
             click.echo("No metadata repository found")
             changed = False

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -8,7 +8,6 @@ import os
 
 from playground_sign._common import (
     bold,
-    bold_blue,
     get_signing_key_input,
     git_expect,
     git_echo,
@@ -32,8 +31,6 @@ def sign(verbose: int, push: bool, event_name: str):
     user_config = SignerConfig(settings_path)
 
     with signing_event(event_name, user_config) as repo:
-        git_hash = git_expect(["rev-parse", "HEAD"])
-        click.echo(bold_blue(f"Signing event {event_name} (commit {git_hash[:7]})"))
         if repo.state == SignerState.UNINITIALIZED:
             click.echo("No metadata repository found")
             changed = False


### PR DESCRIPTION
The tool now mostly describes changes to roles metadata. There are still some gaps:
* This should be accompanied with strict validation (which allows us to not describe the things we validate)
* The key content changes are not yet handled


The code is pretty ugly... but I think it's partly unavoidable: even after better refactoring this is likely a long list of special cases. That said, there's definitely room for refactoring. I'd like to merge this and move on for now but I'll take opinions on this.