### PR TITLE
Use the provided metadata when retrieving signing status.

### DIFF
--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -343,14 +343,15 @@ class PlaygroundRepository(Repository):
         invites = set()
         sigs = set()
         missing_sigs = set()
+        md = self.open(rolename)
 
         # Build list of invites to all delegated roles of rolename
         delegation_names = []
         if rolename == "root":
             delegation_names = ["root", "targets"]
         elif rolename == "targets":
-            if delegator.signed.delegations:
-                delegation_names = delegator.signed.delegations.roles.keys()
+            if md.signed.delegations:
+                delegation_names = md.signed.delegations.roles.keys()
         for delegation_name in delegation_names:
             invites.update(self._state.invited_signers_for_role(delegation_name))
 


### PR DESCRIPTION
Before it the provided metadata was mostly ignored. 
This commit also separates some assignments and return statements to aid for easier debuggability.