### PR TITLE
signer: During close, lookup correct root keys

### DIFF
--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -462,6 +462,11 @@ class SignerRepository(Repository):
                 self._invites[self.user_name].remove(rolename)
                 if not self._invites[self.user_name]:
                     del self._invites[self.user_name]
+
+                # Add role to unsigned list even if the role itself does not change
+                if rolename not in self.unsigned:
+                    self.unsigned.append(rolename)
+
                 changed = True
 
             if role.threshold != config.threshold:

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -295,12 +295,21 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
                 changed =  _update_offline_role(repo, role)
 
         if changed:
-            git_expect(["add", "metadata/"])
             if role:
                 msg = f"'{role}' role/delegation change"
             else:
                 msg = "Initial offline metadata"
+            git_expect(["add", "metadata/"])
             git_expect(["commit", "-m", msg, "--", "metadata"])
+
+            if repo.unsigned:
+                for rolename in repo.unsigned:
+                    click.echo(repo.status(rolename))
+                    repo.sign(rolename)
+
+                git_expect(["add", "metadata/"])
+                git_expect(["commit", "-m", f"Signed by {user_config.user_name}"])
+
             if push:
                 msg = f"Press enter to push changes to {user_config.push_remote}/{event_name}"
                 click.prompt(bold(msg), default=True, show_default=False)

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -43,10 +43,6 @@ def sign(verbose: int, push: bool, event_name: str):
                 assert role_config
                 repo.set_role_config(rolename, role_config, key)
 
-                # Sign the role we are now a signer for
-                if rolename != "root" and rolename not in repo.unsigned:
-                    repo.unsigned.append(rolename)
-
             # Sign everything
             if repo.unsigned:
                 click.echo(f"Your signature is requested for role(s) {repo.unsigned}.")

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -44,10 +44,10 @@ def sign(verbose: int, push: bool, event_name: str):
                 repo.set_role_config(rolename, role_config, key)
 
                 # Sign the role we are now a signer for
-                if rolename != "root":
-                    repo.sign(rolename)
+                if rolename != "root" and rolename not in repo.unsigned:
+                    repo.unsigned.append(rolename)
 
-            # Sign any other roles we may be asked to sign at the same time
+            # Sign everything
             if repo.unsigned:
                 click.echo(f"Your signature is requested for role(s) {repo.unsigned}.")
                 for rolename in repo.unsigned:

--- a/playground/tests/e2e.sh
+++ b/playground/tests/e2e.sh
@@ -131,9 +131,7 @@ signer_init()
         "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW key and press enter
         "0000"              # sign root
-        "0000"              # sign root
         "0000"              # sign targets
-        "0000"              # sign root
         ""                  # press enter to push
     )
 
@@ -166,9 +164,7 @@ signer_init_shorter_snapshot_expiry()
         "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW key and press enter
         "0000"              # sign root
-        "0000"              # sign root
         "0000"              # sign targets
-        "0000"              # sign root
         ""                  # press enter to push
     )
 
@@ -201,7 +197,7 @@ signer_init_multiuser()
         "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW key and press enter
         "0000"              # sign root
-        "0000"              # sign root
+        "0000"              # sign targets
         ""                  # press enter to push
     )
 
@@ -225,7 +221,6 @@ signer_accept_invite()
     INPUT=(
         "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW and press enter
-        "0000"              # sign targets
         "0000"              # sign targets
         ""                  # press enter to push
     )


### PR DESCRIPTION
root is a special case since the signing keys are stored in root itself: 
we should be using both new and old keys in that case

The final PR ended up changing the signing and closing: 
* when roles are saved with `SignerRepository.close()` they are no longer signed even if keys are available
* those roles are added to the `unsigned` list
* after delegation changes (also after accepting an invite), all `unsigned` roles are explicitly signed

Comment below lists some advantages of this.

Fixes #103

Issues:
* There is no test yet: #106
* There is a related issue: if you run `playground-sign` to sign a change where your key has been removed from root, it probably won't notice you should sign: `_user_signature_needed()` should handle the special case of root (and check keys from the known good version as well): #107