### PR TITLE
dependencies: Try to find a working sigstore version/commit

### DIFF
--- a/playground/repo/pyproject.toml
+++ b/playground/repo/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.0.1"
 description = "CI tools for Repository Plaground"
 readme = "README.md"
 dependencies = [
-  "sigstore @ git+https://github.com/sigstore/sigstore-python",
+  "sigstore @ git+https://github.com/sigstore/sigstore-python@7d4af6c5f6732ef12e5bb455962321ebe5cce137",
   "securesystemslib[azurekms, gcpkms, sigstore, pynacl] @ git+https://github.com/secure-systems-lab/securesystemslib",
   "tuf @ git+https://github.com/theupdateframework/python-tuf",
   "click",

--- a/playground/signer/pyproject.toml
+++ b/playground/signer/pyproject.toml
@@ -12,7 +12,7 @@ version = "0.0.1"
 description = "TUF signing tool for Repository Plaground"
 readme = "README.md"
 dependencies = [
-  "sigstore @ git+https://github.com/sigstore/sigstore-python",
+  "sigstore @ git+https://github.com/sigstore/sigstore-python@7d4af6c5f6732ef12e5bb455962321ebe5cce137",
   "securesystemslib[gcpkms,hsm,sigstore] @ git+https://github.com/secure-systems-lab/securesystemslib",
   "tuf @ git+https://github.com/theupdateframework/python-tuf",
   "click",


### PR DESCRIPTION
* sigstore-python 1.1.2 requires tuf ~= 2.1, this does not work because playground requires tuf 3
* Newer sigstore-python releases have not been made yet
* sigstore-python main branch does not work because the API has changed in multiple ways that securesystemslib does not support yet

This commit seems to be one of the few that could work:
* tuf dependency is loosened
* sign module API changes are not yet applied