### PR TITLE
Enable linters and tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: repository-playground end-to-end tests
+name: Lint & test
 
 on:
   push:
@@ -17,30 +17,22 @@ jobs:
         python-version: "3.11"
         cache: 'pip'
 
-    - name: Install system dependencies
+    - name: Install system dependencies for e2e test
       run: |
         sudo apt-get install libfaketime softhsm2
         echo "PYKCS11LIB=/usr/lib/softhsm/libsofthsm2.so" >> $GITHUB_ENV
 
-    - name: Install Python dependencies
-      run: |
-        # TODO install repo and signer in separate environments
-        python -m pip install pynacl
-        python -m pip install pynacl ./playground/repo/
-        python -m pip install pynacl ./playground/signer/
+    - name: Install tox
+      run: python -m pip install tox
 
-    - name: Run tests
-      run: |
-        cd playground/tests
-        ./e2e.sh
+    - name: Signer lint
+      working-directory: playground
+      run: tox -e lint-signer
 
-    - name: Run Playground unit tests
-      run: |
-        cd playground/repo
-        python -m unittest
+    - name: Repository unit tests
+      working-directory: playground
+      run: tox -e test-repo
 
-    - name: Run tests with DEBUG_TESTS
-      if: failure()
-      run: |
-        cd playground/tests
-        DEBUG_TESTS=1 ./e2e.sh
+    - name: End-to-end tests
+      working-directory: playground
+      run: tox -e test-e2e

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -312,6 +312,7 @@ class PlaygroundRepository(Repository):
 
     def _known_good_targets(self, rolename: str) -> Targets:
         """Return Targets from the known good version (signing event start point)"""
+        assert self._prev_dir
         prev_path = os.path.join(self._prev_dir, f"{rolename}.json")
         if os.path.exists(prev_path):
             with open(prev_path, "rb") as f:

--- a/playground/repo/playground/bump_expiring.py
+++ b/playground/repo/playground/bump_expiring.py
@@ -44,16 +44,16 @@ def bump_online(verbose: int, push: bool, publish_dir: str | None) -> None:
     msg = f"Periodic online role version bump and resign\n\n"
     repo = PlaygroundRepository("metadata")
     snapshot_version = repo.bump_expiring("snapshot")
-    if snapshot_version is not None:
+    if snapshot_version is None:
+        timestamp_version = repo.bump_expiring("timestamp")
+        if timestamp_version is not None:
+            msg += f"timestamp v{timestamp_version}."
+    else:
         # if snapshot changes, we need to actually update timestamp content
         _, meta = repo.do_timestamp()
         assert meta
         timestamp_version = repo.timestamp().version
         msg += f"snapshot v{snapshot_version}, timestamp v{timestamp_version}."
-    else:
-        timestamp_version = repo.bump_expiring("timestamp")
-        if timestamp_version is not None:
-            msg += f"timestamp v{timestamp_version}."
 
     if not timestamp_version and not snapshot_version:
         click.echo("No online version bumps needed")

--- a/playground/repo/pyproject.toml
+++ b/playground/repo/pyproject.toml
@@ -24,3 +24,10 @@ playground-status = "playground:status"
 playground-snapshot = "playground:snapshot"
 playground-bump-online = "playground:bump_online"
 playground-bump-offline = "playground:bump_offline"
+
+[[tool.mypy.overrides]]
+module = [
+  "securesystemslib.*",
+  "sigstore.*",
+]
+ignore_missing_imports = "True"

--- a/playground/signer/playground_sign/__init__.py
+++ b/playground/signer/playground_sign/__init__.py
@@ -1,2 +1,4 @@
 from playground_sign.delegate import delegate
 from playground_sign.sign import sign
+
+__all__ = ["delegate", "sign"]

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -118,10 +118,10 @@ def get_signing_key_input() -> Key:
 
 def get_secret_input(secret: str, role: str) -> str:
     # TODO: Fix this so it prints role as well
-    # This currently has an issue when it's called from
-    # SignerRepository._sign(): The role name is always whatever the first calls argument was...
-    # It seems like the role variable becomes part of the closure in _sign() somehow and then
-    # the role value gets reused in later calls.
+    # This currently has an issue when it's called from SignerRepository._sign(): The
+    # role name is always whatever the first calls argument was...
+    # It seems like the role variable becomes part of the closure in _sign() somehow
+    # and then the role value gets reused in later calls.
     msg = f"Enter {secret} to sign"
 
     # special case for tests -- prompt() will lockup trying to hide STDIN:

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -15,6 +15,7 @@ from securesystemslib.signer import HSMSigner, Key, SigstoreSigner
 
 from playground_sign._signer_repository import SignerRepository
 
+
 class SignerConfig:
     def __init__(self, path: str):
         config = ConfigParser()
@@ -33,7 +34,9 @@ class SignerConfig:
 
 
 @contextmanager
-def signing_event(name: str, config: SignerConfig) -> Generator[SignerRepository, None, None]:
+def signing_event(
+    name: str, config: SignerConfig
+) -> Generator[SignerRepository, None, None]:
     toplevel = git(["rev-parse", "--show-toplevel"])
 
     # PyKCS11 (Yubikey support) needs the module path
@@ -60,7 +63,9 @@ def signing_event(name: str, config: SignerConfig) -> Generator[SignerRepository
             metadata_dir = os.path.join(toplevel, "metadata")
 
             click.echo(bold_blue(f"Signing event {name} (commit {event_sha[:7]})"))
-            repo = SignerRepository(metadata_dir, base_metadata_dir, config.user_name, get_secret_input)
+            repo = SignerRepository(
+                metadata_dir, base_metadata_dir, config.user_name, get_secret_input
+            )
             yield repo
     finally:
         # go back to original branch
@@ -73,7 +78,7 @@ def get_signing_key_input() -> Key:
     click.echo(" 2. Yubikey")
     choice = click.prompt(
         bold("Please choose the type of signing key you would like to use"),
-        type=click.IntRange(1,2),
+        type=click.IntRange(1, 2),
         default=1,
     )
 
@@ -84,7 +89,7 @@ def get_signing_key_input() -> Key:
         click.echo(" 3. Microsoft")
         issuer_id = click.prompt(
             bold("Please choose the identity issuer"),
-            type=click.IntRange(1,3),
+            type=click.IntRange(1, 3),
             default=1,
         )
         if issuer_id == 1:
@@ -98,7 +103,11 @@ def get_signing_key_input() -> Key:
         except Exception as e:
             raise click.ClickException(f"Failed to create Sigstore key: {e}")
     else:
-        click.prompt(bold("Please insert your Yubikey and press enter"), default=True, show_default=False)
+        click.prompt(
+            bold("Please insert your Yubikey and press enter"),
+            default=True,
+            show_default=False,
+        )
         try:
             _, key = HSMSigner.import_()
         except Exception as e:
@@ -127,6 +136,7 @@ def git(cmd: list[str]) -> str:
     proc = subprocess.run(cmd, capture_output=True, check=True, text=True)
     return proc.stdout.strip()
 
+
 def git_expect(cmd: list[str]) -> str:
     """Run git, expect success"""
     try:
@@ -135,12 +145,15 @@ def git_expect(cmd: list[str]) -> str:
         print(f"git failure:\n{e.stderr}")
         raise
 
+
 def git_echo(cmd: list[str]):
     cmd = ["git"] + cmd
     subprocess.run(cmd, check=True, text=True)
 
+
 def bold(text: str) -> str:
     return click.style(text, bold=True)
+
 
 def bold_blue(text: str) -> str:
     return click.style(text, bold=True, fg="bright_blue")

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -68,11 +68,9 @@ def signing_event(name: str, config: SignerConfig) -> Generator[SignerRepository
 
 
 def get_signing_key_input() -> Key:
-    click.echo(
-        "\nConfiguring signing key\n"
-        " 1. Sigstore (OpenID Connect)\n"
-        " 2. Yubikey"
-    )
+    click.echo("\nConfiguring signing key")
+    click.echo(" 1. Sigstore (OpenID Connect)")
+    click.echo(" 2. Yubikey")
     choice = click.prompt(
         bold("Please choose the type of signing key you would like to use"),
         type=click.IntRange(1,2),
@@ -81,11 +79,9 @@ def get_signing_key_input() -> Key:
 
     if choice == 1:
         identity = click.prompt(bold("Please enter your email address"))
-        click.echo(
-            " 1. GitHub\n"
-            " 2. Google\n"
-            " 3. Microsoft"
-        )
+        click.echo(" 1. GitHub")
+        click.echo(" 2. Google")
+        click.echo(" 3. Microsoft")
         issuer_id = click.prompt(
             bold("Please choose the identity issuer"),
             type=click.IntRange(1,3),

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -82,9 +82,9 @@ def get_signing_key_input() -> Key:
     if choice == 1:
         identity = click.prompt(bold("Please enter your email address"))
         click.echo(
-            f" 1. GitHub\n"
-            f" 2. Google\n"
-            f" 3. Microsoft"
+            " 1. GitHub\n"
+            " 2. Google\n"
+            " 3. Microsoft"
         )
         issuer_id = click.prompt(
             bold("Please choose the identity issuer"),

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -302,9 +302,9 @@ class SignerRepository(Repository):
         for key in keys:
             md.signatures[key.keyid] = Signature(key.keyid, "")
 
-            # Mark role as unsigned if user is a signer
+            # Mark role as unsigned if user is a signer (and there are no open invites)
             keyowner = key.unrecognized_fields["x-playground-keyowner"]
-            if keyowner == self.user_name:
+            if keyowner == self.user_name and not open_invites:
                 if role not in self.unsigned:
                     self.unsigned.append(role)
 

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -584,7 +584,8 @@ class SignerRepository(Repository):
             )
             if signed.version != 1:
                 output.append(
-                    f"   (expiry period was {old_expiry} days, signing period was {old_signing} days"
+                    f"   (expiry period was {old_expiry} days, "
+                    f"signing period was {old_signing} days"
                 )
 
         return output
@@ -596,7 +597,7 @@ class SignerRepository(Repository):
 
         def _get_signer_name(key: Key) -> str:
             if name in ["timestamp", "snapshot"]:
-                # there's no "signer" in the online case: just use signing system as signer
+                # there's no "signer" in the online case: use signing system as signer
                 uri = key.unrecognized_fields["x-playground-online-uri"]
                 return uri.split(":")[0]
             return key.unrecognized_fields["x-playground-keyowner"]
@@ -615,8 +616,8 @@ class SignerRepository(Repository):
             if root.version > 1:
                 old_delegations = dict(old_root.roles)
 
-            # Use timestamp output for both snapshot and timestamp: NOTE: we should validate that
-            # the delegations really are identical
+            # Use timestamp output for both snapshot and timestamp: NOTE: we should
+            # validate that the delegations really are identical
             delegations.pop("snapshot")
             old_delegations.pop("snapshot", None)
         else:
@@ -656,7 +657,8 @@ class SignerRepository(Repository):
                         f"   * Signers: {role.threshold}/{len(signers)} of {signers}"
                     )
                     output.append(
-                        f"     (was: {old_role.threshold}/{len(old_signers)} of {old_signers}"
+                        f"     (was: {old_role.threshold}/{len(old_signers)} "
+                        f"of {old_signers}"
                     )
                 del old_delegations[name]
 

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -154,7 +154,7 @@ class SignerRepository(Repository):
 
     def _known_good_root(self) -> Root:
         """Return the Root object from the known-good repository state"""
-        prev_path = os.path.join(self._prev_dir, f"root.json")
+        prev_path = os.path.join(self._prev_dir, "root.json")
         if os.path.exists(prev_path):
             with open(prev_path, "rb") as f:
                 md = Metadata.from_bytes(f.read())

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -120,7 +120,7 @@ def _get_online_input(
     config: OnlineConfig, user_config: SignerConfig
 ) -> OnlineConfig:
     config = copy.deepcopy(config)
-    click.echo(f"\nConfiguring online roles")
+    click.echo("\nConfiguring online roles")
     while True:
         keyuri = config.keys[0].unrecognized_fields["x-playground-online-uri"]
         click.echo(
@@ -140,23 +140,23 @@ def _get_online_input(
             config.keys = _collect_online_keys(user_config)
         if choice == 2:
             config.timestamp_expiry = click.prompt(
-                bold(f"Please enter timestamp expiry in days"),
+                bold("Please enter timestamp expiry in days"),
                 type=int,
                 default=config.timestamp_expiry,
             )
             config.timestamp_signing = click.prompt(
-                bold(f"Please enter timestamp signing period in days"),
+                bold("Please enter timestamp signing period in days"),
                 type=int,
                 default=config.timestamp_signing,
             )
         if choice == 3:
             config.snapshot_expiry = click.prompt(
-                bold(f"Please enter snapshot expiry in days"),
+                bold("Please enter snapshot expiry in days"),
                 type=int,
                 default=config.snapshot_expiry,
             )
             config.snapshot_signing = click.prompt(
-                bold(f"Please enter snapshot signing period in days"),
+                bold("Please enter snapshot signing period in days"),
                 type=int,
                 default=config.snapshot_signing,
             )
@@ -168,9 +168,9 @@ def _collect_online_keys(user_config: SignerConfig) -> list[SSlibKey]:
 
     while True:
         click.echo(
-            f" 1. Sigstore\n"
-            f" 2. Google Cloud KMS\n"
-            f" 3. Azure Key Vault"
+            " 1. Sigstore\n"
+            " 2. Google Cloud KMS\n"
+            " 3. Azure Key Vault"
         )
         choice = click.prompt(
             bold("Please select online key type"),
@@ -238,7 +238,7 @@ def _init_repository(repo: SignerRepository, user_config: SignerConfig) -> bool:
     return True
 
 def _update_online_roles(repo: SignerRepository, user_config: SignerConfig) -> bool:
-    click.echo(f"Modifying online roles")
+    click.echo("Modifying online roles")
 
     config = repo.get_online_config()
     new_config = _get_online_input(config, user_config)

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -137,7 +137,7 @@ def _get_online_input(
         if choice == 0:
             break
         if choice == 1:
-            config.keys = _collect_online_keys()
+            config.keys = _collect_online_keys(user_config)
         if choice == 2:
             config.timestamp_expiry = click.prompt(
                 bold(f"Please enter timestamp expiry in days"),
@@ -163,7 +163,7 @@ def _get_online_input(
 
     return config
 
-def _collect_online_keys() -> list[SSlibKey]:
+def _collect_online_keys(user_config: SignerConfig) -> list[SSlibKey]:
     # TODO use value_proc argument to validate the input
 
     while True:

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -45,10 +45,8 @@ def _get_offline_input(
     config = copy.deepcopy(config)
     click.echo(f"\nConfiguring role {role}")
     while True:
-        click.echo(
-            f" 1. Configure signers: [{', '.join(config.signers)}], requiring {config.threshold} signatures\n"
-            f" 2. Configure expiry: Role expires in {config.expiry_period} days, re-signing starts {config.signing_period} days before expiry"
-        )
+        click.echo(f" 1. Configure signers: [{', '.join(config.signers)}], requiring {config.threshold} signatures")
+        click.echo(f" 2. Configure expiry: Role expires in {config.expiry_period} days, re-signing starts {config.signing_period} days before expiry")
         choice = click.prompt(
             bold("Please choose an option or press enter to continue"),
             type=click.IntRange(0, 2),
@@ -123,11 +121,9 @@ def _get_online_input(
     click.echo("\nConfiguring online roles")
     while True:
         keyuri = config.keys[0].unrecognized_fields["x-playground-online-uri"]
-        click.echo(
-            f" 1. Configure online key: {keyuri}\n"
-            f" 2. Configure timestamp: Expires in {config.timestamp_expiry} days, re-signing starts {config.timestamp_signing} days before expiry\n"
-            f" 3. Configure snapshot: Expires in {config.snapshot_expiry} days, re-signing starts {config.snapshot_signing} days before expiry"
-        )
+        click.echo(f" 1. Configure online key: {keyuri}")
+        click.echo(f" 2. Configure timestamp: Expires in {config.timestamp_expiry} days, re-signing starts {config.timestamp_signing} days before expiry")
+        click.echo(f" 3. Configure snapshot: Expires in {config.snapshot_expiry} days, re-signing starts {config.snapshot_signing} days before expiry")
         choice = click.prompt(
             bold("Please choose an option or press enter to continue"),
             type=click.IntRange(0, 3),
@@ -167,11 +163,9 @@ def _collect_online_keys(user_config: SignerConfig) -> list[SSlibKey]:
     # TODO use value_proc argument to validate the input
 
     while True:
-        click.echo(
-            " 1. Sigstore\n"
-            " 2. Google Cloud KMS\n"
-            " 3. Azure Key Vault"
-        )
+        click.echo(" 1. Sigstore")
+        click.echo(" 2. Google Cloud KMS")
+        click.echo(" 3. Azure Key Vault")
         choice = click.prompt(
             bold("Please select online key type"),
             type=click.IntRange(1, 4),

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -47,10 +47,12 @@ def _get_offline_input(
     click.echo(f"\nConfiguring role {role}")
     while True:
         click.echo(
-            f" 1. Configure signers: [{', '.join(config.signers)}], requiring {config.threshold} signatures"
+            f" 1. Configure signers: [{', '.join(config.signers)}], "
+            f"requiring {config.threshold} signatures"
         )
         click.echo(
-            f" 2. Configure expiry: Role expires in {config.expiry_period} days, re-signing starts {config.signing_period} days before expiry"
+            f" 2. Configure expiry: Role expires in {config.expiry_period} days, "
+            f"re-signing starts {config.signing_period} days before expiry"
         )
         choice = click.prompt(
             bold("Please choose an option or press enter to continue"),
@@ -76,7 +78,7 @@ def _get_offline_input(
             if len(config.signers) == 1:
                 config.threshold = 1
             else:
-                # TODO use value_proc argument to validate threshold is [1-len(new_signers)]
+                # TODO  validate threshold is within [1, len(new_signers)] ?
                 config.threshold = click.prompt(
                     bold(f"Please enter {role} threshold"),
                     type=int,
@@ -131,10 +133,12 @@ def _get_online_input(config: OnlineConfig, user_config: SignerConfig) -> Online
         keyuri = config.keys[0].unrecognized_fields["x-playground-online-uri"]
         click.echo(f" 1. Configure online key: {keyuri}")
         click.echo(
-            f" 2. Configure timestamp: Expires in {config.timestamp_expiry} days, re-signing starts {config.timestamp_signing} days before expiry"
+            f" 2. Configure timestamp: Expires in {config.timestamp_expiry} days,"
+            f" re-signing starts {config.timestamp_signing} days before expiry"
         )
         click.echo(
-            f" 3. Configure snapshot: Expires in {config.snapshot_expiry} days, re-signing starts {config.snapshot_signing} days before expiry"
+            f" 3. Configure snapshot: Expires in {config.snapshot_expiry} days, "
+            f"re-signing starts {config.snapshot_signing} days before expiry"
         )
         choice = click.prompt(
             bold("Please choose an option or press enter to continue"),
@@ -205,16 +209,15 @@ def _collect_online_keys(user_config: SignerConfig) -> list[SSlibKey]:
             except Exception as e:
                 raise click.ClickException(f"Failed to read Azure Keyvault key: {e}")
         if choice == 4:
-            # This could be generic support for env var keys... but for now is just for the one testing key
-            # the private key is 1d9a024348e413892aeeb8cc8449309c152f48177200ee61a02ae56f450c6480
+            # This could be generic support, but for now it's a hidden test key.
+            # key value 1d9a024348e413892aeeb8cc8449309c152f48177200ee61a02ae56f450c6480
             uri = "envvar:LOCAL_TESTING_KEY"
+            pub_key = "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
             key = SSlibKey(
                 "fa47289",
                 "ed25519",
                 "ed25519",
-                {
-                    "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
-                },
+                {"public": pub_key},
                 {"x-playground-online-uri": uri},
             )
             return [key]
@@ -335,7 +338,8 @@ def delegate(verbose: int, push: bool, event_name: str, role: str | None):
                 git_expect(["commit", "-m", f"Signed by {user_config.user_name}"])
 
             if push:
-                msg = f"Press enter to push changes to {user_config.push_remote}/{event_name}"
+                branch = f"{user_config.push_remote}/{event_name}"
+                msg = f"Press enter to push changes to {branch}"
                 click.prompt(bold(msg), default=True, show_default=False)
                 git_echo(
                     [

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -68,7 +68,8 @@ def sign(verbose: int, push: bool, event_name: str):
             git_expect(["add", "metadata"])
             git_expect(["commit", "-m", f"Signed by {user_config.user_name}"])
             if push:
-                msg = f"Press enter to push signature(s) to {user_config.push_remote}/{event_name}"
+                branch = f"{user_config.push_remote}/{event_name}"
+                msg = f"Press enter to push signature(s) to {branch}"
                 click.prompt(bold(msg), default=True, show_default=False)
                 git_echo(
                     [

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -18,6 +18,7 @@ from playground_sign._signer_repository import SignerState
 
 logger = logging.getLogger(__name__)
 
+
 @click.command()
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("--push/--no-push", default=True)
@@ -35,7 +36,9 @@ def sign(verbose: int, push: bool, event_name: str):
             click.echo("No metadata repository found")
             changed = False
         elif repo.state == SignerState.INVITED:
-            click.echo(f"You have been invited to become a signer for role(s) {repo.invites}.")
+            click.echo(
+                f"You have been invited to become a signer for role(s) {repo.invites}."
+            )
             key = get_signing_key_input()
             for rolename in repo.invites.copy():
                 # Modify the delegation
@@ -67,7 +70,14 @@ def sign(verbose: int, push: bool, event_name: str):
             if push:
                 msg = f"Press enter to push signature(s) to {user_config.push_remote}/{event_name}"
                 click.prompt(bold(msg), default=True, show_default=False)
-                git_echo(["push", "--progress", user_config.push_remote, f"HEAD:refs/heads/{event_name}"])
+                git_echo(
+                    [
+                        "push",
+                        "--progress",
+                        user_config.push_remote,
+                        f"HEAD:refs/heads/{event_name}",
+                    ]
+                )
             else:
                 # TODO: maybe deal with existing branch?
                 click.echo(f"Creating local branch {event_name}")

--- a/playground/signer/pyproject.toml
+++ b/playground/signer/pyproject.toml
@@ -22,3 +22,9 @@ requires-python = ">=3.10"
 [project.scripts]
 playground-delegate = "playground_sign:delegate"
 playground-sign = "playground_sign:sign"
+
+[[tool.mypy.overrides]]
+module = [
+  "securesystemslib.*",
+]
+ignore_missing_imports = "True"

--- a/playground/tox.ini
+++ b/playground/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-env_list = lint
+env_list = lint-signer, test-repo, test-e2e
 
-[testenv:lint]
-description = Linters
+[testenv:lint-signer]
+description = Signer Linting
+labels = lint
 deps =
     -e signer/
     ruff
@@ -14,3 +15,26 @@ commands =
     ruff .
     mypy .
     black --check --diff .
+
+[testenv:test-repo]
+description = Repository unit tests
+labels = test
+deps =
+    -e repo/
+
+changedir = repo
+commands =
+    python -m unittest
+
+[testenv:test-e2e]
+# See tests/README.md for the system dependencies
+description = End-to-end tests with mocked GitHub Actions
+labels = test
+deps =
+    -e repo/
+    -e signer/
+    pynacl
+
+changedir = tests
+commands =
+    ./e2e.sh

--- a/playground/tox.ini
+++ b/playground/tox.ini
@@ -7,8 +7,10 @@ deps =
     -e signer/
     ruff
     mypy
+    black
 
 changedir = signer
 commands =
-    # ruff .
+    ruff .
     mypy .
+    black --check --diff .

--- a/playground/tox.ini
+++ b/playground/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+env_list = lint
+
+[testenv:lint]
+description = Linters
+deps =
+    -e signer/
+    ruff
+    mypy
+
+changedir = signer
+commands =
+    # ruff .
+    mypy .


### PR DESCRIPTION
* added tox config
* Defined environments for linters and the tests we have now
* fixed a lot of things in signer/ to make linters happy: intention is to not have functional changes in the source code
* Enabled tox testing and linting on CI
* After the initial run (that installs dependencies)  tox is pretty snappy.
* repo is not linted yet

There is no documentation included, but 
```shell
# requirements to use tox 
pip install tox

# run specific tox envs
tox -e lint-signer
tox -e test-e2e

# run labels (that may contain multiple envs)
tox -m test
tox -m lint
```