### PR TITLE
Fixes for issues found while demo dry run

### DIFF
--- a/playground/actions/signing-event/action.yml
+++ b/playground/actions/signing-event/action.yml
@@ -45,7 +45,7 @@ runs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Signing event: " + process.env.GITHUB_REF_NAME,
-              body: "TODO: document signing event here",
+              body: "Processing signing event " + process.env.GITHUB_REF_NAME + ", please wait.",
               labels: [process.env.GITHUB_REF_NAME],
             })
             issue = response.data.number

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -323,7 +323,9 @@ class SignerRepository(Repository):
             # signing event
             keys = self._get_keys(role)
 
-        # wipe signatures
+        # wipe signatures, update "unsigned" list
+        if role in self.unsigned:
+            self.unsigned.remove(role)
         md.signatures.clear()
         for key in keys:
             md.signatures[key.keyid] = Signature(key.keyid, "")

--- a/playground/tests/e2e.sh
+++ b/playground/tests/e2e.sh
@@ -196,7 +196,6 @@ signer_init_multiuser()
         ""                  # Configure online roles? [enter to continue]
         "2"                 # Choose signing key [2: yubikey]
         ""                  # Insert HW key and press enter
-        "0000"              # sign root
         "0000"              # sign targets
         ""                  # press enter to push
     )


### PR DESCRIPTION
@lukas: I think these both make sense to merge, assuming we can still do a dry-run tomorrow to make sure it all works.

Changes are:
* signer: Don't ask for a signature if there are invites to delegated roles (this was a regression that happened when I changed when signing happens: the test input was wrong too, otherwise we would have noticed)
* signing event: don't say "TODO"