### PR TITLE
Configurable deployment

### DIFF
--- a/playground/actions/online-version-bump/action.yml
+++ b/playground/actions/online-version-bump/action.yml
@@ -13,11 +13,9 @@ inputs:
   metadata_path:
     description: 'Path where to store the metadata files in the published repository'
     required: true
-    default: '/'
   targets_path:
     description: 'Path where to store the target files in the published repository'
     required: true
-    default: 'targets
 
 outputs:
   generated:

--- a/playground/actions/online-version-bump/action.yml
+++ b/playground/actions/online-version-bump/action.yml
@@ -52,7 +52,7 @@ runs:
         mkdir publish
         cd repository
         if playground-bump-online --push --metadata ${{ inputs.metadata_path}} --targets ${{ inputs.targets_path}} ../publish; then
-          find -type f "../publish" | xargs ls -lh
+          find "../publish" -type f | xargs ls -lh
           echo "generated=true" >> $GITHUB_OUTPUT
         else
           echo "generated=false" >> $GITHUB_OUTPUT

--- a/playground/actions/online-version-bump/action.yml
+++ b/playground/actions/online-version-bump/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: 'Google Cloud service account name'
     required: false
     default: ''
+  metadata_path:
+    description: 'Path where to store the metadata files in the published repository'
+    required: true
+    default: '/'
+  targets_path:
+    description: 'Path where to store the target files in the published repository'
+    required: true
+    default: 'targets
 
 outputs:
   generated:
@@ -43,7 +51,7 @@ runs:
       run: |
         mkdir publish
         cd repository
-        if playground-bump-online --push ../publish; then
+        if playground-bump-online --push ../publish --metadata ${{ inputs.metadata_path}} --target ${{ inputs.targets_path}}; then
           ls -l "../publish"
           echo "generated=true" >> $GITHUB_OUTPUT
         else

--- a/playground/actions/online-version-bump/action.yml
+++ b/playground/actions/online-version-bump/action.yml
@@ -51,7 +51,7 @@ runs:
       run: |
         mkdir publish
         cd repository
-        if playground-bump-online --push ../publish --metadata ${{ inputs.metadata_path}} --target ${{ inputs.targets_path}}; then
+        if playground-bump-online --push --metadata ${{ inputs.metadata_path}} --targets ${{ inputs.targets_path}} ../publish; then
           find -type f "../publish" | xargs ls -lh
           echo "generated=true" >> $GITHUB_OUTPUT
         else

--- a/playground/actions/online-version-bump/action.yml
+++ b/playground/actions/online-version-bump/action.yml
@@ -52,7 +52,7 @@ runs:
         mkdir publish
         cd repository
         if playground-bump-online --push ../publish --metadata ${{ inputs.metadata_path}} --target ${{ inputs.targets_path}}; then
-          ls -l "../publish"
+          find -type f "../publish" | xargs ls -lh
           echo "generated=true" >> $GITHUB_OUTPUT
         else
           echo "generated=false" >> $GITHUB_OUTPUT

--- a/playground/actions/snapshot/action.yml
+++ b/playground/actions/snapshot/action.yml
@@ -51,7 +51,7 @@ runs:
         mkdir publish
         cd repository
         if playground-snapshot --push --metadata ${{ inputs.metadata_path}} --targets ${{ inputs.targets_path}} ../publish; then
-          find -type f "../publish" | xargs ls -lh
+          find "../publish" -type f | xargs ls -lh
           echo "generated=true" >> $GITHUB_OUTPUT
         else
           echo "generated=false" >> $GITHUB_OUTPUT

--- a/playground/actions/snapshot/action.yml
+++ b/playground/actions/snapshot/action.yml
@@ -10,6 +10,14 @@ inputs:
     description: 'Google Cloud service account name'
     required: false
     default: ''
+  metadata_path:
+    description: 'Path where to store the metadata files in the published repository'
+    required: true
+    default: '/'
+  targets_path:
+    description: 'Path where to store the target files in the published repository'
+    required: true
+    default: 'targets'
 
 outputs:
   generated:
@@ -42,8 +50,7 @@ runs:
       run: |
         mkdir publish
         cd repository
-
-        if playground-snapshot --push ../publish; then
+        if playground-snapshot --push ../publish --metadata ${{ inputs.metadata_path}} --target ${{ inputs.targets_path}}; then
           ls -l "../publish"
           echo "generated=true" >> $GITHUB_OUTPUT
         else

--- a/playground/actions/snapshot/action.yml
+++ b/playground/actions/snapshot/action.yml
@@ -50,7 +50,7 @@ runs:
       run: |
         mkdir publish
         cd repository
-        if playground-snapshot --push ../publish --metadata ${{ inputs.metadata_path}} --target ${{ inputs.targets_path}}; then
+        if playground-snapshot --push --metadata ${{ inputs.metadata_path}} --targets ${{ inputs.targets_path}} ../publish; then
           find -type f "../publish" | xargs ls -lh
           echo "generated=true" >> $GITHUB_OUTPUT
         else

--- a/playground/actions/snapshot/action.yml
+++ b/playground/actions/snapshot/action.yml
@@ -51,7 +51,7 @@ runs:
         mkdir publish
         cd repository
         if playground-snapshot --push ../publish --metadata ${{ inputs.metadata_path}} --target ${{ inputs.targets_path}}; then
-          ls -l "../publish"
+          find -type f "../publish" | xargs ls -lh
           echo "generated=true" >> $GITHUB_OUTPUT
         else
           echo "generated=false" >> $GITHUB_OUTPUT

--- a/playground/actions/snapshot/action.yml
+++ b/playground/actions/snapshot/action.yml
@@ -13,11 +13,9 @@ inputs:
   metadata_path:
     description: 'Path where to store the metadata files in the published repository'
     required: true
-    default: '/'
   targets_path:
     description: 'Path where to store the target files in the published repository'
     required: true
-    default: 'targets'
 
 outputs:
   generated:

--- a/playground/repo/playground/_playground_repository.py
+++ b/playground/repo/playground/_playground_repository.py
@@ -440,7 +440,7 @@ class PlaygroundRepository(Repository):
     def status(self, rolename: str) -> tuple[SigningStatus, SigningStatus | None]:
         """Returns signing status for role.
 
-        In case of root, another SigningStatus may be returned for the previous 
+        In case of root, another SigningStatus may be returned for the previous
         'known good' root.
         Uses .signing-event-state file."""
         if rolename in ["timestamp", "snapshot"]:
@@ -450,9 +450,25 @@ class PlaygroundRepository(Repository):
         signing_event_status = self._get_signing_status(rolename, known_good=False)
         return signing_event_status, known_good_status
 
-    def publish(self, directory: str):
-        metadata_dir = os.path.join(directory, "metadata")
-        targets_dir = os.path.join(directory, "targets")
+    def publish(self, directory: str, metadata_path: str, targets_path: str):
+        def clean_path(p: str):
+            if p.startswith('/'):
+                return p[1:]
+            return p
+
+        metadata_path = clean_path(metadata_path)
+        targets_path = clean_path(targets_path)
+
+        if metadata_path == '':
+            metadata_dir = directory
+        else:
+            metadata_dir = os.path.join(directory, metadata_path)
+
+        if targets_path == '':
+            targets_dir = directory
+        else:
+            targets_dir = os.path.join(directory, targets_path)
+
         os.makedirs(metadata_dir, exist_ok=True)
 
         for src_path in glob(os.path.join(self._dir, "root_history", "*.root.json")):

--- a/playground/repo/playground/bump_expiring.py
+++ b/playground/repo/playground/bump_expiring.py
@@ -29,8 +29,10 @@ def _git(cmd: list[str]) -> subprocess.CompletedProcess:
 @click.command()
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("--push/--no-push", default=False)
+@click.option("--metadata", required=True)
+@click.option("--targets", required=True)
 @click.argument("publish-dir", required=False)
-def bump_online(verbose: int, push: bool, publish_dir: str | None) -> None:
+def bump_online(verbose: int, push: bool, metadata: str, targets: str, publish_dir: str | None) -> None:
     """Commit new metadata versions for online roles if needed
 
     New versions will be signed.
@@ -67,7 +69,7 @@ def bump_online(verbose: int, push: bool, publish_dir: str | None) -> None:
         _git(["push", "origin", "HEAD"])
 
     if publish_dir:
-        repo.publish(publish_dir)
+        repo.publish(publish_dir, metadata, targets)
         click.echo(f"New repository snapshot generated and published in {publish_dir}")
     else:
         click.echo(f"New repository snapshot generated")

--- a/playground/repo/playground/snapshot.py
+++ b/playground/repo/playground/snapshot.py
@@ -29,8 +29,10 @@ def _git(cmd: list[str]) -> subprocess.CompletedProcess:
 @click.command()
 @click.option("-v", "--verbose", count=True, default=0)
 @click.option("--push/--no-push", default=False)
+@click.option("--metadata", required=True)
+@click.option("--targets", required=True)
 @click.argument("publish-dir", required=False)
-def snapshot(verbose: int, push: bool, publish_dir: str | None) -> None:
+def snapshot(verbose: int, push: bool, metadata: str, targets: str, publish_dir: str | None) -> None:
     """Update The TUF snapshot based on current repository content
 
     Create a commit with the snapshot and timestamp changes (if any).
@@ -56,7 +58,7 @@ def snapshot(verbose: int, push: bool, publish_dir: str | None) -> None:
         _git(["push", "origin", "HEAD"])
 
     if publish_dir:
-        repo.publish(publish_dir)
+        repo.publish(publish_dir, metadata, targets)
         click.echo(f"New repository snapshot generated and published in {publish_dir}")
     else:
         click.echo(f"New repository snapshot generated")

--- a/playground/tests/e2e.sh
+++ b/playground/tests/e2e.sh
@@ -369,7 +369,7 @@ repo_snapshot()
     cd $REPO_GIT
 
 
-    if LOCAL_TESTING_KEY=$ONLINE_KEY playground-snapshot --push $PUBLISH_DIR >> $REPO_DIR/out 2>&1; then
+    if LOCAL_TESTING_KEY=$ONLINE_KEY playground-snapshot --push --metadata metadata --targets targets $PUBLISH_DIR >> $REPO_DIR/out 2>&1; then
         echo "generated=true" >> $REPO_DIR/out
     else
         echo "generated=false" >> $REPO_DIR/out
@@ -383,7 +383,7 @@ repo_bump_versions()
 
     cd $REPO_GIT
 
-    if LOCAL_TESTING_KEY=$ONLINE_KEY playground-bump-online --push $PUBLISH_DIR >> $REPO_DIR/out 2>&1; then
+    if LOCAL_TESTING_KEY=$ONLINE_KEY playground-bump-online --push --metadata metadata --targets targets $PUBLISH_DIR >> $REPO_DIR/out 2>&1; then
         echo "generated=true" >> $REPO_DIR/out
     else
         echo "generated=false" >> $REPO_DIR/out


### PR DESCRIPTION
Closes #122 

The version bump and snapshot composite actions are now updated to accept two new parameters:
* `metadata_path`: the path inside the `publish` directory for the metadata, default is `/`, ie the root of the publish directory
* `targets_path`: the path inside the `publish` directory for the targets, default is `targets`. 

The parameters are provided to the `publish` method which makes sure to publish the metadata and targets accordingly, and then the final artifact is uploaded to pages.