### PR TITLE
signing-event: Use the repos API instead of search API

### DIFF
--- a/playground/actions/signing-event/action.yml
+++ b/playground/actions/signing-event/action.yml
@@ -35,12 +35,14 @@ runs:
 
           issue = 0
           const repo = context.repo.owner + "/" + context.repo.repo
-          const issues = await github.rest.search.issuesAndPullRequests({
-            q: "label:" + process.env.GITHUB_REF_NAME + "+state:open+type:issue+repo:" + repo,
+          const issues = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: process.env.GITHUB_REF_NAME,
           })
-          if (issues.data.total_count > 1) {
+          if (issues.data.length > 1) {
             core.setFailed("Found more than one issue with same label")
-          } else if (issues.data.total_count == 0) {
+          } else if (issues.data.length == 0) {
             const response = await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -51,7 +53,7 @@ runs:
             issue = response.data.number
             console.log("Created issue #" + issue)
           } else {
-            issue = issues.data.items[0].number
+            issue = issues.data[0].number
             console.log("Found existing issue #" + issue)
           }
 


### PR DESCRIPTION
Former is arguably the correct choice for finding a repositorys open issues and latter is broken today.

Differences:
* new API lists only open issues by default
* new API does not allow filtering by issue type (so we would find PRs too): I don't think this is an issue as the PRs do not get a label automatically and we are searching based on label
* new API return value is of course just slightly different from old API return value