### PR TITLE
A bit hackish fix for letting previous root signer sign current.

### DIFF
--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -136,13 +136,13 @@ def git(cmd: list[str]) -> str:
     proc = subprocess.run(cmd, capture_output=True, check=True, text=True)
     return proc.stdout.strip()
 
-
 def git_expect(cmd: list[str]) -> str:
     """Run git, expect success"""
     try:
         return git(cmd)
     except subprocess.CalledProcessError as e:
         print(f"git failure:\n{e.stderr}")
+        print(f"\n{e.stdout}")
         raise
 
 

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -136,6 +136,7 @@ def git(cmd: list[str]) -> str:
     proc = subprocess.run(cmd, capture_output=True, check=True, text=True)
     return proc.stdout.strip()
 
+
 def git_expect(cmd: list[str]) -> str:
     """Run git, expect success"""
     try:

--- a/playground/tests/expected/root-key-rotation/metadata/1.root.json
+++ b/playground/tests/expected/root-key-rotation/metadata/1.root.json
@@ -1,0 +1,65 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2022-02-03T01:02:03Z",
+  "keys": {
+   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-playground-keyowner": "@playgrounduser1"
+   },
+   "fa47289": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
+    },
+    "scheme": "ed25519",
+    "x-playground-online-uri": "envvar:LOCAL_TESTING_KEY"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 365,
+    "x-playground-signing-period": 60
+   },
+   "targets": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 2,
+    "x-playground-signing-period": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1,
+  "x-playground-expiry-period": 365,
+  "x-playground-signing-period": 60
+ }
+}

--- a/playground/tests/expected/root-key-rotation/metadata/1.snapshot.json
+++ b/playground/tests/expected/root-key-rotation/metadata/1.snapshot.json
@@ -1,0 +1,19 @@
+{
+ "signatures": [
+  {
+   "keyid": "fa47289",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "snapshot",
+  "expires": "2022-02-03T01:02:03Z",
+  "meta": {
+   "targets.json": {
+    "version": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1
+ }
+}

--- a/playground/tests/expected/root-key-rotation/metadata/1.targets.json
+++ b/playground/tests/expected/root-key-rotation/metadata/1.targets.json
@@ -1,0 +1,17 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "targets",
+  "expires": "2022-02-03T01:02:03Z",
+  "spec_version": "1.0.31",
+  "targets": {},
+  "version": 1,
+  "x-playground-expiry-period": 365,
+  "x-playground-signing-period": 60
+ }
+}

--- a/playground/tests/expected/root-key-rotation/metadata/timestamp.json
+++ b/playground/tests/expected/root-key-rotation/metadata/timestamp.json
@@ -1,0 +1,19 @@
+{
+ "signatures": [
+  {
+   "keyid": "fa47289",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "timestamp",
+  "expires": "2021-02-05T01:02:03Z",
+  "meta": {
+   "snapshot.json": {
+    "version": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 1
+ }
+}


### PR DESCRIPTION
Also print stdout when capturing git error as it's not always printed to stderr

Fixes: #130 