### PR TITLE
Snapshot publish fix

### DIFF
--- a/playground/actions/snapshot/action.yml
+++ b/playground/actions/snapshot/action.yml
@@ -19,8 +19,9 @@ inputs:
 
 outputs:
   generated:
+    # Currently always true: a repository artifact is published every time
     description: "'true' if a new repository version was uploaded"
-    value: ${{ steps.snapshot.outputs.generated }}
+    value: true
 
 runs:
   using: "composite"
@@ -48,16 +49,12 @@ runs:
       run: |
         mkdir publish
         cd repository
-        if playground-snapshot --push --metadata ${{ inputs.metadata_path}} --targets ${{ inputs.targets_path}} ../publish; then
-          find "../publish" -type f | xargs ls -lh
-          echo "generated=true" >> $GITHUB_OUTPUT
-        else
-          echo "generated=false" >> $GITHUB_OUTPUT
-        fi
+        playground-snapshot --push --metadata ${{ inputs.metadata_path}} --targets ${{ inputs.targets_path}} ../publish
+
+        find "../publish" -type f | xargs ls -lh
       shell: bash
 
     - name: Upload repository artifact for GitHub Pages
-      if: steps.snapshot.outputs.generated == 'true'
       uses: actions/upload-pages-artifact@253fd476ed429e83b7aae64a92a75b4ceb1a17cf
       with:
         path: publish/

--- a/playground/repo/playground/snapshot.py
+++ b/playground/repo/playground/snapshot.py
@@ -3,7 +3,6 @@
 """Command line tool to update snapshot (and timestamp) for Repository Playground CI"""
 
 import subprocess
-import sys
 import click
 import logging
 
@@ -39,8 +38,6 @@ def snapshot(
     Create a commit with the snapshot and timestamp changes (if any).
     If --push, the commit is pushed to origin.
     If publish-dir is provided, a repository snapshot is generated into that directory
-
-    returns 1 if no snapshot was generated
     """
     logging.basicConfig(level=logging.WARNING - verbose * 10)
 
@@ -48,18 +45,15 @@ def snapshot(
     snapshot_updated, _ = repo.do_snapshot()
     if not snapshot_updated:
         click.echo("No snapshot needed")
-        sys.exit(1)
+    else:
+        repo.do_timestamp()
 
-    repo.do_timestamp()
-
-    msg = "Snapshot & timestamp"
-    _git(["add", "metadata/timestamp.json", "metadata/snapshot.json"])
-    _git(["commit", "-m", msg])
-    if push:
-        _git(["push", "origin", "HEAD"])
+        msg = "Snapshot & timestamp"
+        _git(["add", "metadata/timestamp.json", "metadata/snapshot.json"])
+        _git(["commit", "-m", msg])
+        if push:
+            _git(["push", "origin", "HEAD"])
 
     if publish_dir:
         repo.publish(publish_dir, metadata, targets)
-        click.echo(f"New repository snapshot generated and published in {publish_dir}")
-    else:
-        click.echo("New repository snapshot generated")
+        click.echo(f"New repository version published in {publish_dir}")

--- a/playground/tests/e2e.sh
+++ b/playground/tests/e2e.sh
@@ -517,9 +517,6 @@ test_multi_user_signing()
     signer_sign user1 sign/change-online
     # merge successful signing event, create new snapshot
     repo_merge sign/change-online
-    # FIXME: This does not publish the latest changes as expected:
-    # Only root was changed, this leads to snapshot deciding no publish
-    # is necessary. See issue #101.
     repo_snapshot
 
     # Verify test result
@@ -607,9 +604,6 @@ test_root_key_rotation()
     signer_sign user1 sign/new-root
     # signing event is now finished
     repo_merge sign/new-root
-    # FIXME: This does not publish the latest changes as expected:
-    # Only root was changed, this leads to snapshot deciding no publish
-    # is necessary. See issue #101.
     repo_snapshot
 
     # Verify test result

--- a/playground/tests/expected/multi-user-signing/metadata/2.root.json
+++ b/playground/tests/expected/multi-user-signing/metadata/2.root.json
@@ -1,0 +1,74 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2022-02-03T01:02:03Z",
+  "keys": {
+   "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+jBdFHGUlKUilRL3/ReI6whKNbCZk8CL\nJFGVf5JypwD/2lr7d/6owMGuqd9ocCVVHw2GsuGRS7aCQfEvEsTgal6y2NC2gGpi\n1rsv2TGRzxKeZ7m0yX4h/vXlfJe7xys9\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-playground-keyowner": "@playgrounduser2"
+   },
+   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-playground-keyowner": "@playgrounduser1"
+   },
+   "fa47289": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
+    },
+    "scheme": "ed25519",
+    "x-playground-online-uri": "envvar:LOCAL_TESTING_KEY"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 365,
+    "x-playground-signing-period": 60
+   },
+   "targets": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+     "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198"
+    ],
+    "threshold": 2
+   },
+   "timestamp": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 5,
+    "x-playground-signing-period": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 2,
+  "x-playground-expiry-period": 365,
+  "x-playground-signing-period": 60
+ }
+}

--- a/playground/tests/expected/root-key-rotation/metadata/2.root.json
+++ b/playground/tests/expected/root-key-rotation/metadata/2.root.json
@@ -1,0 +1,77 @@
+{
+ "signatures": [
+  {
+   "keyid": "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999",
+   "sig": "XXX"
+  },
+  {
+   "keyid": "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198",
+   "sig": "XXX"
+  }
+ ],
+ "signed": {
+  "_type": "root",
+  "consistent_snapshot": true,
+  "expires": "2022-02-03T01:02:03Z",
+  "keys": {
+   "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+jBdFHGUlKUilRL3/ReI6whKNbCZk8CL\nJFGVf5JypwD/2lr7d/6owMGuqd9ocCVVHw2GsuGRS7aCQfEvEsTgal6y2NC2gGpi\n1rsv2TGRzxKeZ7m0yX4h/vXlfJe7xys9\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-playground-keyowner": "@playgrounduser2"
+   },
+   "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999": {
+    "keytype": "ecdsa",
+    "keyval": {
+     "public": "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ3pswWmx9Bx2VBcpqaooQFA7dQnhRafh\ntj942eg086x6EMHdfgdox9TbwGm7sU2sn/gyjyDr1ez8Ld2ORnyYJ8cAlegfTqNq\nE0eSrLrb+YpzQJxLwh6qWcSngF99Unft\n-----END PUBLIC KEY-----\n"
+    },
+    "scheme": "ecdsa-sha2-nistp384",
+    "x-playground-keyowner": "@playgrounduser1"
+   },
+   "fa47289": {
+    "keytype": "ed25519",
+    "keyval": {
+     "public": "fa472895c9756c2b9bcd1440bf867d0fa5c4edee79e9792fa9822be3dd6fcbb3"
+    },
+    "scheme": "ed25519",
+    "x-playground-online-uri": "envvar:LOCAL_TESTING_KEY"
+   }
+  },
+  "roles": {
+   "root": {
+    "keyids": [
+     "204fd0866b874c8ba288726cb9c3e41fcdf22dd36c95816d31b7cbfb7b68b198"
+    ],
+    "threshold": 1
+   },
+   "snapshot": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 365,
+    "x-playground-signing-period": 60
+   },
+   "targets": {
+    "keyids": [
+     "95da323daa78f7b2557ae91e23be619ff932f9aec035abd4e40301405b363999"
+    ],
+    "threshold": 1
+   },
+   "timestamp": {
+    "keyids": [
+     "fa47289"
+    ],
+    "threshold": 1,
+    "x-playground-expiry-period": 2,
+    "x-playground-signing-period": 1
+   }
+  },
+  "spec_version": "1.0.31",
+  "version": 2,
+  "x-playground-expiry-period": 365,
+  "x-playground-signing-period": 60
+ }
+}


### PR DESCRIPTION
Always publish a new repository version after a snapshot: previously we had an issue where signing events that only touched root metadata would not get published (because a snapshot would not get generated and then publish would not be done)

The real check pre-publish would be _"has any metadata changed since the last publish time"_ which may mean that we should use a branch to mark which commit we last published (something I've planned otherwise too). This PR is simpler however and starts publishing every time snapshot process runs: this currently means on every push to main 