### PR TITLE
signer: Store key uris in config file

### DIFF
--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -48,7 +48,7 @@ def signing_event(name: str, user: User) -> Generator[SignerRepository, None, No
         git_expect(["checkout", "-"])
 
 
-def get_signing_key_input() -> Key:
+def get_signing_key_input() -> tuple[str, Key]:
     click.echo("\nConfiguring signing key")
     click.echo(" 1. Sigstore (OpenID Connect)")
     click.echo(" 2. Yubikey")
@@ -75,7 +75,7 @@ def get_signing_key_input() -> Key:
         else:
             issuer = "https://login.microsoftonline.com"
         try:
-            _, key = SigstoreSigner.import_(identity, issuer, ambient=False)
+            uri, key = SigstoreSigner.import_(identity, issuer, ambient=False)
         except Exception as e:
             raise click.ClickException(f"Failed to create Sigstore key: {e}")
     else:
@@ -85,11 +85,11 @@ def get_signing_key_input() -> Key:
             show_default=False,
         )
         try:
-            _, key = HSMSigner.import_()
+            uri, key = HSMSigner.import_()
         except Exception as e:
             raise click.ClickException(f"Failed to read HW key: {e}")
 
-    return key
+    return uri, key
 
 
 def git(cmd: list[str]) -> str:

--- a/playground/signer/playground_sign/_common.py
+++ b/playground/signer/playground_sign/_common.py
@@ -11,7 +11,8 @@ import click
 
 from securesystemslib.signer import HSMSigner, Key, SigstoreSigner
 
-from playground_sign._signer_repository import SignerRepository, User
+from playground_sign._signer_repository import SignerRepository
+from playground_sign._user import User
 
 
 @contextmanager

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -78,7 +78,7 @@ class User:
     def __init__(self, path: str):
         self._config_path = path
 
-        self._config = ConfigParser()
+        self._config = ConfigParser(interpolation=None)
         self._config.read(path)
 
         # TODO: create config if missing, ask/confirm values from user

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -74,6 +74,7 @@ class OfflineConfig:
 
 class User:
     """Class that manages user configuration and stores the signer cache for the user"""
+
     def __init__(self, path: str):
         self._config_path = path
 
@@ -136,6 +137,17 @@ class User:
             self._signers[key.keyid] = Signer.from_priv_key_uri("hsm:", key, get_secret)
 
         return self._signers[key.keyid]
+
+    def store_signer(self, uri: str, key: Key) -> None:
+        """Store the uri in the signing-keys section of the config file"""
+        self._signing_key_uris[key.keyid] = uri
+
+        if "signing-keys" not in self._config:
+            self._config.add_section("signing-keys")
+        self._config["signing-keys"][key.keyid] = uri
+
+        with open(self._config_path, "w") as f:
+            self._config.write(f)
 
 
 def blue(text: str) -> str:

--- a/playground/signer/playground_sign/_signer_repository.py
+++ b/playground/signer/playground_sign/_signer_repository.py
@@ -2,9 +2,7 @@
 
 """Internal repository module for playground signer tool"""
 
-from configparser import ConfigParser
 from contextlib import AbstractContextManager
-import sys
 import click
 import filecmp
 import json
@@ -38,6 +36,7 @@ from tuf.api.metadata import (
 from tuf.api.serialization.json import CanonicalJSONSerializer, JSONSerializer
 from tuf.repository import Repository, AbortEdit
 
+from playground_sign._user import User
 
 logger = logging.getLogger(__name__)
 
@@ -72,95 +71,8 @@ class OfflineConfig:
     signing_period: int
 
 
-class User:
-    """Class that manages user configuration and stores the signer cache for the user"""
-
-    def __init__(self, path: str):
-        self._config_path = path
-
-        self._config = ConfigParser(interpolation=None)
-        self._config.read(path)
-
-        # TODO: create config if missing, ask/confirm values from user
-        if not self._config:
-            raise click.ClickException(f"Settings file {path} not found")
-        try:
-            self.name = self._config["settings"]["user-name"]
-            self.pykcs11lib = self._config["settings"]["pykcs11lib"]
-            self.push_remote = self._config["settings"]["push-remote"]
-            self.pull_remote = self._config["settings"]["pull-remote"]
-        except KeyError as e:
-            raise click.ClickException(f"Failed to find required setting {e} in {path}")
-
-        # signing key config is not required
-        if "signing-keys" in self._config:
-            self._signing_key_uris = dict(self._config.items("signing-keys"))
-        else:
-            self._signing_key_uris = {}
-
-        # signer cache gets populated as they are used the first time
-        self._signers: dict[str, Signer] = {}
-
-    def get_signer(self, key: Key) -> Signer:
-        """Returns a Signer for the given public key
-
-        The signer sources are (in order):
-        * any configured signer from 'signing-keys' config section
-        * for sigstore type keys, a Signer is automatically created
-        * for any remaining keys, HSM is assumed and a signer is created
-        """
-
-        def get_secret(secret: str) -> str:
-            msg = f"Enter {secret} to sign"
-
-            # special case for tests -- prompt() will lockup trying to hide STDIN:
-            if not sys.stdin.isatty():
-                return sys.stdin.readline().rstrip()
-
-            return click.prompt(bold(msg), hide_input=True)
-
-        if key.keyid in self._signers:
-            # signer is already cached
-            pass
-        elif key.keyid in self._signing_key_uris:
-            # signer is not cached yet, but the uri was configured
-            uri = self._signing_key_uris[key.keyid]
-            self._signers[key.keyid] = Signer.from_priv_key_uri(uri, key, get_secret)
-
-        elif key.keytype == "sigstore-oidc":
-            # signer is not cached, no configuration was found, type is sigstore
-            self._signers[key.keyid] = Signer.from_priv_key_uri(
-                "sigstore:?ambient=false", key, get_secret
-            )
-        else:
-            # signer is not cached, no configuration was found: assume Yubikey
-            self._signers[key.keyid] = Signer.from_priv_key_uri("hsm:", key, get_secret)
-
-        return self._signers[key.keyid]
-
-    def store_signer(self, uri: str, key: Key) -> None:
-        """Store the uri in the signing-keys section of the config file"""
-
-        # NOTE Currently we set the uri and commit to a file immediately:
-        # it might make sense to separate these steps so that we could only commit
-        # after the whole process has finished (e.g. no git issues or something)
-
-        self._signing_key_uris[key.keyid] = uri
-
-        if "signing-keys" not in self._config:
-            self._config.add_section("signing-keys")
-        self._config["signing-keys"][key.keyid] = uri
-
-        with open(self._config_path, "w") as f:
-            self._config.write(f)
-
-
 def blue(text: str) -> str:
     return click.style(text, fg="bright_blue")
-
-
-def bold(text: str) -> str:
-    return click.style(text, bold=True)
 
 
 def _find_changed_roles(known_good_dir: str, signing_event_dir: str) -> list[str]:
@@ -320,7 +232,7 @@ class SignerRepository(Repository):
             for keyid in r.keyids:
                 keys.append(delegator.get_key(keyid))
         except ValueError:
-            pass # either no role delegated yet or key not found
+            pass  # either no role delegated yet or key not found
 
         return keys
 

--- a/playground/signer/playground_sign/_user.py
+++ b/playground/signer/playground_sign/_user.py
@@ -1,0 +1,94 @@
+import click
+import sys
+from configparser import ConfigParser
+from securesystemslib.signer import Key, Signer
+
+
+def bold(text: str) -> str:
+    return click.style(text, bold=True)
+
+
+class User:
+    """Class that manages user configuration and stores the signer cache for the user"""
+
+    def __init__(self, path: str):
+        self._config_path = path
+
+        self._config = ConfigParser(interpolation=None)
+        self._config.read(path)
+
+        # TODO: create config if missing, ask/confirm values from user
+        if not self._config:
+            raise click.ClickException(f"Settings file {path} not found")
+        try:
+            self.name = self._config["settings"]["user-name"]
+            self.pykcs11lib = self._config["settings"]["pykcs11lib"]
+            self.push_remote = self._config["settings"]["push-remote"]
+            self.pull_remote = self._config["settings"]["pull-remote"]
+        except KeyError as e:
+            raise click.ClickException(f"Failed to find required setting {e} in {path}")
+
+        # signing key config is not required
+        if "signing-keys" in self._config:
+            self._signing_key_uris = dict(self._config.items("signing-keys"))
+        else:
+            self._signing_key_uris = {}
+
+        # signer cache gets populated as they are used the first time
+        self._signers: dict[str, Signer] = {}
+
+    def get_signer(self, key: Key) -> Signer:
+        """Returns a Signer for the given public key
+
+        The signer sources are (in order):
+        * any configured signer from 'signing-keys' config section
+        * for sigstore type keys, a Signer is automatically created
+        * for any remaining keys, HSM is assumed and a signer is created
+        """
+
+        def get_secret(secret: str) -> str:
+            msg = f"Enter {secret} to sign"
+
+            # special case for tests -- prompt() will lockup trying to hide STDIN:
+            if not sys.stdin.isatty():
+                return sys.stdin.readline().rstrip()
+
+            return click.prompt(bold(msg), hide_input=True)
+
+        if key.keyid in self._signers:
+            # signer is already cached
+            pass
+        elif key.keyid in self._signing_key_uris:
+            # signer is not cached yet, but the uri was configured
+            uri = self._signing_key_uris[key.keyid]
+            self._signers[key.keyid] = Signer.from_priv_key_uri(uri, key, get_secret)
+
+        elif key.keytype == "sigstore-oidc":
+            # signer is not cached, no configuration was found, type is sigstore
+            self._signers[key.keyid] = Signer.from_priv_key_uri(
+                "sigstore:?ambient=false", key, get_secret
+            )
+        else:
+            # signer is not cached, no configuration was found: assume Yubikey
+            self._signers[key.keyid] = Signer.from_priv_key_uri("hsm:", key, get_secret)
+
+        return self._signers[key.keyid]
+
+    def store_signer(self, uri: str, key: Key) -> None:
+        """Store the uri in the signing-keys section of the config file"""
+        # NOTE that this currently rewrites the whole config file, removing all comments
+        # Maybe we should not store key details in this file but in a separate
+        # application data file that is not really user visible?
+
+        # NOTE Currently we set the uri and commit to a file immediately:
+        # it might make sense to separate these steps so that we could only commit
+        # if the whole process is successful (e.g. no git issues or something)
+
+        self._signing_key_uris[key.keyid] = uri
+
+        if "signing-keys" not in self._config:
+            self._config.add_section("signing-keys")
+        self._config["signing-keys"][key.keyid] = uri
+
+        with open(self._config_path, "w") as f:
+            self._config.write(f)

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -252,11 +252,13 @@ def _init_repository(repo: SignerRepository) -> bool:
         repo.user.name in root_config.signers
         or repo.user.name in targets_config.signers
     ):
-        key = get_signing_key_input()
+        uri, key = get_signing_key_input()
+        repo.user.store_signer(uri, key)
 
     repo.set_role_config("root", root_config, key)
     repo.set_role_config("targets", targets_config, key)
     repo.set_online_config(online_config)
+
     return True
 
 
@@ -288,7 +290,8 @@ def _update_offline_role(repo: SignerRepository, role: str) -> bool:
 
     key = None
     if repo.user.name in new_config.signers:
-        key = get_signing_key_input()
+        uri, key = get_signing_key_input()
+        repo.user.store_signer(uri, key)
 
     repo.set_role_config(role, new_config, key)
     return True

--- a/playground/signer/playground_sign/delegate.py
+++ b/playground/signer/playground_sign/delegate.py
@@ -21,7 +21,6 @@ from playground_sign._common import (
     get_signing_key_input,
     git_expect,
     git_echo,
-    User,
     signing_event,
 )
 from playground_sign._signer_repository import (
@@ -30,6 +29,7 @@ from playground_sign._signer_repository import (
     SignerRepository,
     SignerState,
 )
+from playground_sign._user import User
 
 
 # sigstore is not a supported key by default

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -39,7 +39,9 @@ def sign(verbose: int, push: bool, event_name: str):
             click.echo(
                 f"You have been invited to become a signer for role(s) {repo.invites}."
             )
-            key = get_signing_key_input()
+            uri, key = get_signing_key_input()
+            repo.user.store_signer(uri, key)
+
             for rolename in repo.invites.copy():
                 # Modify the delegation
                 role_config = repo.get_role_config(rolename)

--- a/playground/signer/playground_sign/sign.py
+++ b/playground/signer/playground_sign/sign.py
@@ -11,10 +11,10 @@ from playground_sign._common import (
     get_signing_key_input,
     git_expect,
     git_echo,
-    User,
     signing_event,
 )
 from playground_sign._signer_repository import SignerState
+from playground_sign._user import User
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
DRAFT: I'm still thinking if I want this...

* Store signer uris in configuration file
* refactor the code so that there is now a class that manages user configuration (and the signer uris) 

This allows at least:
* using multiple yubikeys without issues
* noticing more user mistakes: likeusing the wrong yubikey
* using e.g. file based keys (the UI currently does not support them but if the metadata contains them and the config has a uri, it will work)